### PR TITLE
CouchDB Appender

### DIFF
--- a/lib/appenders/couch.js
+++ b/lib/appenders/couch.js
@@ -1,0 +1,53 @@
+var nano = require("nano"),
+    util = require("util"),
+    async = require("async");
+
+var C = {//backup of console.log; in case of infinity loops after console replacement
+  log: function() {
+    process.stdout.write(util.format.apply(this, arguments) + '\n');
+  },
+  error: function() {
+    process.stderr.write(util.format.apply(this, arguments) + '\n');
+  }
+};
+
+function createAppender(opts) {
+  var db, endpoint;
+  
+  opts = opts || {};
+  opts.host = opts.host || "localhost";
+  opts.secured = (typeof opts.secure == "undefined") ? false : opts.secured;
+  opts.port = 5984;
+  opts.protocol = opts.secured ? "https" : "http";
+  opts.db = opts.db || "logs";
+  endpoint = [opts.protocol, "://", opts.host, ":", opts.port, "/", opts.db].join("");
+  db = nano(endpoint);
+  
+  return function(loggingEvent) {
+    var logs, m, d;
+
+    d = new Date(loggingEvent.startTime);
+    m = {
+      date: [d.getFullYear(), d.getMonth()+1, d.getDate(), d.getHours(), d.getMinutes(), d.getSeconds()],
+      category: loggingEvent.categoryName
+    };
+    logs = loggingEvent.data.map(function(item, i) {
+      return {
+        date: m.date,
+        category: m.category,
+        data: item
+      };
+    });
+    db.bulk({docs: logs}, function(e) {
+      if(e) C.error(e);
+    });
+  };
+}
+
+function configure(config, options) {
+  var opt = options.couch ? options.couch : config;
+  return createAppender(opt);
+}
+
+exports.appender = createAppender;
+exports.configure = configure;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
        "vows": "0.6.2",
        "sandboxed-module": "0.1.3",
        "hook.io": "0.8.10",
-       "underscore": "1.2.1"
+       "underscore": "1.2.1",
+       "nano": "*"
    }
 }

--- a/test/couch-test.js
+++ b/test/couch-test.js
@@ -1,0 +1,22 @@
+var path = require('path')
+, log4js = require('../lib/log4js')
+, assert = require('assert')
+, nano = require('nano')
+, util = require('util');
+
+
+var logger = log4js.getLogger('default-settings')
+, db = nano("http://localhost:5984/logs")
+, feed = db.follow({since: "now", include_doc: true});
+
+  log4js.clearAppenders();
+  log4js.addAppender(require('../lib/appenders/couch').appender(), 'default-settings');
+  
+  feed.once('change', function(change) {
+    var db = nano("http://localhost:5984/logs");
+    db.get(change.id, function(e, doc) {
+      console.log(doc);
+    });
+  });
+  feed.follow();
+  logger.info("This should be in local couchdb.");

--- a/test/local-couchAppender-test.js
+++ b/test/local-couchAppender-test.js
@@ -1,0 +1,36 @@
+var vows = require('vows')
+, fs = require('fs')
+, path = require('path')
+, log4js = require('../lib/log4js')
+, assert = require('assert')
+, nano = require('nano')
+, util = require('util');
+
+
+log4js.clearAppenders();
+
+vows.describe('log4js couchAppender').addBatch({
+
+    'with default couchAppender settings': {
+        topic: function() {
+          var that = this
+          ,logger = log4js.getLogger('default-settings')
+          , db = nano("http://localhost:5984/logs")
+          , feed = db.follow({since: "now", include_doc: true});
+
+            log4js.clearAppenders();
+            log4js.addAppender(require('../lib/appenders/couch').appender(), 'default-settings');
+            
+            feed.once('change', that.callback);
+            feed.follow();
+            logger.info("This should be in local couchdb.");
+
+        },
+        'should write log messages to the couchdb': function(change) {
+            var db = nano("http://localhost:5984/logs");
+            db.get(change.id, function(e, doc) {
+              assert.include(doc.data, "This should be in local couchdb.");
+            });
+        }
+    }
+}).export(module);


### PR DESCRIPTION
Using couchdb as log appender.

Defaults to store all log info in localhost:5984. Pass db info by:

```js

log4js.addAppender(require('../lib/appenders/couch').appender({
  host: "localhost",
  port: 5984,
  protocol: "http",
  db: "logs"
}), 'default-settings');

```