### PR TITLE
Added an option to compress rolled dateFile logs

### DIFF
--- a/lib/appenders/dateFile.js
+++ b/lib/appenders/dateFile.js
@@ -18,15 +18,19 @@ process.on('exit', function() {
  * @filename base filename.
  * @pattern the format that will be added to the end of filename when rolling,
  *          also used to check when to roll files - defaults to '.yyyy-MM-dd'
+ * @compress boolean that dictates if rolled files should be compressed
  * @layout layout function for log messages - defaults to basicLayout
  */
-function appender(filename, pattern, alwaysIncludePattern, layout) {
+function appender(filename, pattern, alwaysIncludePattern, compress, layout) {
   layout = layout || layouts.basicLayout;
 
   var logFile = new streams.DateRollingFileStream(
     filename, 
     pattern, 
-    { alwaysIncludePattern: alwaysIncludePattern }
+    {
+      alwaysIncludePattern: alwaysIncludePattern,
+      compress: compress
+    }
   );
   openFiles.push(logFile);
   
@@ -46,12 +50,17 @@ function configure(config, options) {
   if (!config.alwaysIncludePattern) {
     config.alwaysIncludePattern = false;
   }
+
+  if (!config.compress) {
+    config.compress = false;
+  }
   
   if (options && options.cwd && !config.absolute) {
     config.filename = path.join(options.cwd, config.filename);
   }
 
-  return appender(config.filename, config.pattern, config.alwaysIncludePattern, layout);
+  return appender(config.filename, config.pattern, config.alwaysIncludePattern,
+                  config.compress, layout);
 }
 
 exports.appender = appender;

--- a/lib/streams/DateRollingFileStream.js
+++ b/lib/streams/DateRollingFileStream.js
@@ -4,7 +4,8 @@ var BaseRollingFileStream = require('./BaseRollingFileStream')
 , format = require('../date_format')
 , async = require('async')
 , fs = require('fs')
-, util = require('util');
+, util = require('util')
+, zlib = require('zlib');
 
 module.exports = DateRollingFileStream;
 
@@ -20,13 +21,18 @@ function DateRollingFileStream(filename, pattern, options, now) {
   this.lastTimeWeWroteSomething = format.asString(this.pattern, new Date(this.now()));
   this.baseFilename = filename;
   this.alwaysIncludePattern = false;
-  
+  this.shouldCompress = false;
+
   if (options) {
     if (options.alwaysIncludePattern) {
       this.alwaysIncludePattern = true;
       filename = this.baseFilename + this.lastTimeWeWroteSomething;
     }
     delete options.alwaysIncludePattern;
+    if (options.compress) {
+      this.shouldCompress = true;
+    }
+    delete options.compress;
     if (Object.keys(options).length === 0) { 
       options = null; 
     }
@@ -59,6 +65,7 @@ DateRollingFileStream.prototype.roll = function(filename, callback) {
     this.filename = this.baseFilename + this.lastTimeWeWroteSomething;
     async.series([
       this.closeTheStream.bind(this),
+      compressIfRequested.bind(this),
       this.openTheStream.bind(this)
     ], callback);
   } else {
@@ -67,6 +74,7 @@ DateRollingFileStream.prototype.roll = function(filename, callback) {
       this.closeTheStream.bind(this),
       deleteAnyExistingFile,
       renameTheCurrentFile,
+      compressIfRequested.bind(this),
       this.openTheStream.bind(this)
     ], callback);
   }
@@ -83,6 +91,24 @@ DateRollingFileStream.prototype.roll = function(filename, callback) {
   function renameTheCurrentFile(cb) {
     debug("Renaming the " + filename + " -> " + newFilename);
     fs.rename(filename, newFilename, cb);
+  }
+
+  function compressIfRequested(cb) {
+    var fileToCompress = (newFilename) ? newFilename : filename
+      , compressedFile = fileToCompress + '.gz'
+      , inp
+      , out;
+    if (this.shouldCompress) {
+      debug("Compressing " + newFilename);
+      inp = fs.createReadStream(fileToCompress);
+      out = fs.createWriteStream(compressedFile);
+      inp.pipe(zlib.createGzip()).pipe(out);
+      out.on('finish', function() {
+        fs.unlink(fileToCompress, cb);
+      });
+    } else {
+      cb();
+    }
   }
 
 };


### PR DESCRIPTION
Usage:

``` javascript
log4js.configure({
  "appenders": [ {
    "type": "dateFile",
    "filename": "blah.log",
    "pattern": "-yyyy-MM-dd",
    "alwaysIncludePattern": false,
    "compress": true // new option
  } ]
});
```
