### PR TITLE
added cluster identifier support

### DIFF
--- a/lib/appenders/clustered.js
+++ b/lib/appenders/clustered.js
@@ -87,6 +87,15 @@ function createAppender(config) {
 					// console.log("master : " + cluster.isMaster + " received message: " + JSON.stringify(message.event));
 					
 					var loggingEvent = deserializeLoggingEvent(message.event);
+					
+					// Adding PID metadata
+					loggingEvent.pid = worker.process.pid;
+					loggingEvent.cluster = {
+						master: process.pid,
+						worker: worker.process.pid,
+						workerId: worker.id
+					};
+					
 					masterAppender(loggingEvent);
 				}
 			});

--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -145,7 +145,7 @@ function messagePassThroughLayout (loggingEvent) {
  */
 function patternLayout (pattern, tokens) {
   var TTCC_CONVERSION_PATTERN  = "%r %p %c - %m%n";
-  var regex = /%(-?[0-9]+)?(\.?[0-9]+)?([\[\]cdhmnprzx%])(\{([^\}]+)\})?|([^%]+)/;
+  var regex = /%(-?[0-9]+)?(\.?[0-9]+)?([\[\]cdhmnprzxy%])(\{([^\}]+)\})?|([^%]+)/;
   
   pattern = pattern || TTCC_CONVERSION_PATTERN;
 
@@ -212,8 +212,25 @@ function patternLayout (pattern, tokens) {
     return '%';
   }
 
-  function pid() {
-    return process.pid;
+  function pid(loggingEvent) {
+    if (loggingEvent.pid) {
+      return loggingEvent.pid;
+    } else {
+      return process.pid;
+    }
+  }
+  
+  function clusterInfo(loggingEvent, specifier) {
+    if (loggingEvent.cluster && specifier) {
+      return specifier
+        .replace('%m', loggingEvent.cluster.master)
+        .replace('%w', loggingEvent.cluster.worker)
+        .replace('%i', loggingEvent.cluster.workerId);
+    } else if (loggingEvent.cluster) {
+      return loggingEvent.cluster.worker+'@'+loggingEvent.cluster.master;
+    } else {
+      return pid();
+    }
   }
 
   function userDefined(loggingEvent, specifier) {
@@ -237,6 +254,7 @@ function patternLayout (pattern, tokens) {
     'r': startTime,
     '[': startColour,
     ']': endColour,
+    'y': clusterInfo,
     'z': pid,
     '%': percent,
     'x': userDefined

--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -213,7 +213,7 @@ function patternLayout (pattern, tokens) {
   }
 
   function pid(loggingEvent) {
-    if (loggingEvent.pid) {
+    if (loggingEvent && loggingEvent.pid) {
       return loggingEvent.pid;
     } else {
       return process.pid;


### PR DESCRIPTION
I modified the clustered appender so it will add the original process identifier as well as an object containing cluster metadata.

I then modified the layouts.js file, first by rewriting the pid() function which will preferably use the loggingEvent.pid variable so that the log message will have the appropriate PID attached to it. I then implemented a new function, clusterInfo(), which allows you to write cluster-specific meta-data if available, with support for a custom pattern.

I'm not familiar with the unit-testing framework, hence no tests, but they should be pretty straight-forward.