### PR TITLE
Force bundling of appenders/console

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -65,6 +65,8 @@ var events = require('events')
   replaceConsole: false
 };
 
+require('./appenders/console');
+
 function hasLogger(logger) {
   return loggers.hasOwnProperty(logger);
 }


### PR DESCRIPTION
### Changes to be committed:
	modified:   lib/log4js.js

### Comment 
Please refer to  [How to use with Browserify?](https://github.com/nomiddlename/log4js-node/issues/263) 

I do not know if this change is necessary, or if a better method is already known.

I am using my own copy in the meantime with this clause in the package.json of my project : 

      "dependencies": {
        "private-log4js": "git+ssh://git@github.com:FleetingClouds/log4js-node.git",
    }

### Note
If you too are noob, trying to figure all this out, I've made a bare minimum example of how I did it : [Baby Steps](https://github.com/FleetingClouds/javascript-bdd-baby-steps/tree/master/Browserify)
