### PR TITLE
Update smtp.js

### DIFF
--- a/lib/appenders/smtp.js
+++ b/lib/appenders/smtp.js
@@ -34,9 +34,15 @@ function smtpAppender(config, layout) {
       var msg = {
         to: config.recipients,
         subject: config.subject || subjectLayout(firstEvent),
-        text: body,
         headers: { "Hostname": os.hostname() }
       };
+	  
+      if (!config.html) {
+	msg.text = body;
+      } else {
+    	msg.html = body;
+      }
+      
       if (config.sender) {
         msg.from = config.sender;
       }


### PR DESCRIPTION
added the ability for smtp appender to send message as html instead of plaintext. in your log4js.config file simply include "html": "true", to write out as html, otherwise it will send plaintext