### PR TITLE
Allow for blank tokens due to dynamic data

### DIFF
--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -295,9 +295,7 @@ function patternLayout (pattern, tokens) {
       } else {
         // Create a raw replacement string based on the conversion
         // character and specifier
-        var replacement = 
-          replaceToken(conversionCharacter, loggingEvent, specifier) || 
-          matchedString;
+        var replacement = replaceToken(conversionCharacter, loggingEvent, specifier);
 
         // Format the replacement according to any padding or
         // truncation specified

--- a/test/layouts-test.js
+++ b/test/layouts-test.js
@@ -282,14 +282,14 @@ vows.describe('log4js layouts').addBatch({
       test(args, '%x{testFunction}', 'testFunctionToken');
     },
     '%x{doesNotExist} should output the string stored in tokens': function(args) {
-      test(args, '%x{doesNotExist}', '%x{doesNotExist}');
+      test(args, '%x{doesNotExist}', 'null');
     },
     '%x{fnThatUsesLogEvent} should be able to use the logEvent': function(args) {
       test(args, '%x{fnThatUsesLogEvent}', 'DEBUG');
     },
     '%x should output the string stored in tokens': function(args) {
-      test(args, '%x', '%x');
-    },
+      test(args, '%x', 'null');
+    }
   },
   'layout makers': {
     topic: require('../lib/layouts'),


### PR DESCRIPTION
Metadata for users such as name, email, etc are not always present for users.  For example, I am running express and I want to log the %x{company}%x{username} so that when I look at my logs I can immediately understand which user this affects.  Or for example, I could log %x{payingOrTial} the type of user.  

This works well when the user is logged in.  However, my logger encompasses everything.  I log when the server boots up.  I log during the login screen where a user is not yet logged in.  In these circumstances there is no way to retrieve this metadata.

So for example

```
"username": function () {
            var session = require('continuation-local-storage').getNamespace('api.callinize');
            if(!session) session = require('continuation-local-storage').getNamespace('dashboard.callinize');
            var username = session && session.get('user') && session.get('user').username;
            if(!username) return "";
            return " " + username + " ";
        }
```

I try to get the metadata.  If I get no metdata I return a blank string.  Unfortunately, in the current implementation, due to the OR operator, even if I have a replacement of "" || matchedString, 

```
  replaceToken(conversionCharacter, loggingEvent, specifier) || 
          matchedString;
```

the blank string equals false and puts the token in the log instead of the blank string.  This makes the log lines get long with information that is not relevant.  The better thing to do is simply allow for blank strings.  This lets the user have control over their logs and also allows for more metadata to go in the logs, without having to pick only metadata that is always present.