### PR TITLE
Add method to get all registered loggers

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -165,6 +165,15 @@ function getLogger (loggerCategoryName) {
 }
 
 /**
+ * Get the list of loggers attached. Useful for identifying all registered loggers and changing one or more log levels at once.
+ * @return {Object} containing all attached loggers.
+ * @static
+ */
+function getLoggers() {
+  return loggers;
+}
+
+/**
  * args are appender, then zero or more categories
  */
 function addAppender () {
@@ -448,6 +457,7 @@ function shutdown(cb) {
 module.exports = {
   getBufferedLogger: getBufferedLogger,
   getLogger: getLogger,
+  getLoggers: getLoggers,
   getDefaultLogger: getDefaultLogger,
   hasLogger: hasLogger,
   


### PR DESCRIPTION
Provides a mechanism for grabbing all of the registered loggers held by log4js. This can be useful for seeing everything that's currently been registered. This could be used by some handler that changes one or more log levels on the fly.
