### PR TITLE
enable chaining

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -43,10 +43,12 @@ Logger.prototype.level = levels.TRACE;
 
 Logger.prototype.setLevel = function(level) {
   this.level = levels.toLevel(level, this.level || levels.TRACE);
+  return this;
 };
 
 Logger.prototype.removeLevel = function() {
   delete this.level;
+  return this;
 };
 
 Logger.prototype.log = function() {


### PR DESCRIPTION
Make possible write like this:

```
log4js.replaceConsole(logger.getLogger().setLevel('WARN'));
```

instead of:

```
log4js.replaceConsole((function(){var logger = getLogger(); logger.setLevel('WARN'); return logger;})());
```
