### PR TITLE
Add appender-level timezone offset config

### DIFF
--- a/lib/appenders/console.js
+++ b/lib/appenders/console.js
@@ -2,10 +2,10 @@
 var layouts = require('../layouts')
 , consoleLog = console.log.bind(console);
 
-function consoleAppender (layout) {
+function consoleAppender (layout, timezoneOffset) {
   layout = layout || layouts.colouredLayout;
   return function(loggingEvent) {
-    consoleLog(layout(loggingEvent));
+    consoleLog(layout(loggingEvent, timezoneOffset));
   };
 }
 
@@ -14,7 +14,7 @@ function configure(config) {
   if (config.layout) {
     layout = layouts.layout(config.layout.type, config.layout);
   }
-  return consoleAppender(layout);
+  return consoleAppender(layout, config.timezoneOffset);
 }
 
 exports.appender = consoleAppender;

--- a/lib/appenders/dateFile.js
+++ b/lib/appenders/dateFile.js
@@ -20,8 +20,9 @@ process.on('exit', function() {
  * @pattern the format that will be added to the end of filename when rolling,
  *          also used to check when to roll files - defaults to '.yyyy-MM-dd'
  * @layout layout function for log messages - defaults to basicLayout
+ * @timezoneOffset optional timezone offset in minutes - defaults to system local
  */
-function appender(filename, pattern, alwaysIncludePattern, layout) {
+function appender(filename, pattern, alwaysIncludePattern, layout, timezoneOffset) {
   layout = layout || layouts.basicLayout;
 
   var logFile = new streams.DateRollingFileStream(
@@ -32,7 +33,7 @@ function appender(filename, pattern, alwaysIncludePattern, layout) {
   openFiles.push(logFile);
 
   return function(logEvent) {
-    logFile.write(layout(logEvent) + eol, "utf8");
+    logFile.write(layout(logEvent, timezoneOffset) + eol, "utf8");
   };
 
 }
@@ -52,7 +53,7 @@ function configure(config, options) {
     config.filename = path.join(options.cwd, config.filename);
   }
 
-  return appender(config.filename, config.pattern, config.alwaysIncludePattern, layout);
+  return appender(config.filename, config.pattern, config.alwaysIncludePattern, layout, config.timezoneOffset);
 }
 
 function shutdown(cb) {

--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -26,8 +26,10 @@ process.on('exit', function() {
  *   if not provided then logs won't be rotated.
  * @param numBackups - the number of log files to keep after logSize 
  *   has been reached (default 5)
+ * @param compress - flag that controls log file compression
+ * @param timezoneOffset - optional timezone offset in minutes (default system local)
  */
-function fileAppender (file, layout, logSize, numBackups, compress) {
+function fileAppender (file, layout, logSize, numBackups, compress, timezoneOffset) {
   var bytesWritten = 0;
   file = path.normalize(file);
   layout = layout || layouts.basicLayout;
@@ -64,7 +66,7 @@ function fileAppender (file, layout, logSize, numBackups, compress) {
   openFiles.push(logFile);
 
   return function(loggingEvent) {
-    logFile.write(layout(loggingEvent) + eol, "utf8");
+    logFile.write(layout(loggingEvent, timezoneOffset) + eol, "utf8");
   };
 
 }
@@ -79,7 +81,7 @@ function configure(config, options) {
     config.filename = path.join(options.cwd, config.filename);
   }
 
-  return fileAppender(config.filename, layout, config.maxLogSize, config.backups, config.compress);
+  return fileAppender(config.filename, layout, config.maxLogSize, config.backups, config.compress, config.timezoneOffset);
 }
 
 function shutdown(cb) {

--- a/lib/appenders/fileSync.js
+++ b/lib/appenders/fileSync.js
@@ -127,8 +127,10 @@ RollingFileSync.prototype.write = function(chunk, encoding) {
  *   if not provided then logs won't be rotated.
  * @param numBackups - the number of log files to keep after logSize 
  *   has been reached (default 5)
+ * @param timezoneOffset - optional timezone offset in minutes
+ *   (default system local)
  */
-function fileAppender (file, layout, logSize, numBackups) {
+function fileAppender (file, layout, logSize, numBackups, timezoneOffset) {
   debug("fileSync appender created");
   var bytesWritten = 0;
   file = path.normalize(file);
@@ -166,7 +168,7 @@ function fileAppender (file, layout, logSize, numBackups) {
   var logFile = openTheStream(file, logSize, numBackups);
   
   return function(loggingEvent) {
-    logFile.write(layout(loggingEvent) + eol);
+    logFile.write(layout(loggingEvent, timezoneOffset) + eol);
   };
 }
 
@@ -180,7 +182,7 @@ function configure(config, options) {
     config.filename = path.join(options.cwd, config.filename);
   }
 
-  return fileAppender(config.filename, layout, config.maxLogSize, config.backups);
+  return fileAppender(config.filename, layout, config.maxLogSize, config.backups, config.timezoneOffset);
 }
 
 exports.appender = fileAppender;

--- a/lib/appenders/smtp.js
+++ b/lib/appenders/smtp.js
@@ -28,7 +28,7 @@ function smtpAppender(config, layout) {
       var firstEvent = logEventBuffer[0];
       var body = "";
       while (logEventBuffer.length > 0) {
-        body += layout(logEventBuffer.shift()) + "\n";
+        body += layout(logEventBuffer.shift(), config.timezoneOffset) + "\n";
       }
 
       var msg = {

--- a/lib/date_format.js
+++ b/lib/date_format.js
@@ -21,9 +21,9 @@ function addZero(vNumber) {
  * Thanks to http://www.svendtofte.com/code/date_format/
  * @private
  */
-function offset(date) {
+function offset(timezoneOffset) {
   // Difference to Greenwich time (GMT) in hours
-  var os = Math.abs(date.getTimezoneOffset());
+  var os = Math.abs(timezoneOffset);
   var h = String(Math.floor(os/60));
   var m = String(os%60);
   if (h.length == 1) {
@@ -32,26 +32,31 @@ function offset(date) {
   if (m.length == 1) {
     m = "0" + m;
   }
-  return date.getTimezoneOffset() < 0 ? "+"+h+m : "-"+h+m;
+  return timezoneOffset < 0 ? "+"+h+m : "-"+h+m;
 }
 
-exports.asString = function(/*format,*/ date) {
+exports.asString = function(/*format,*/ date, timezoneOffset) {
   var format = exports.ISO8601_FORMAT;
   if (typeof(date) === "string") {
     format = arguments[0];
     date = arguments[1];
+    timezoneOffset = arguments[2];
   }
-
-  var vDay = addZero(date.getDate());
-  var vMonth = addZero(date.getMonth()+1);
-  var vYearLong = addZero(date.getFullYear());
-  var vYearShort = addZero(date.getFullYear().toString().substring(2,4));
+  // make the date independent of the system timezone by working with UTC
+  if (timezoneOffset === undefined) {
+      timezoneOffset = date.getTimezoneOffset();
+  }
+  date.setUTCMinutes(date.getUTCMinutes() - timezoneOffset);
+  var vDay = addZero(date.getUTCDate());
+  var vMonth = addZero(date.getUTCMonth()+1);
+  var vYearLong = addZero(date.getUTCFullYear());
+  var vYearShort = addZero(date.getUTCFullYear().toString().substring(2,4));
   var vYear = (format.indexOf("yyyy") > -1 ? vYearLong : vYearShort);
-  var vHour  = addZero(date.getHours());
-  var vMinute = addZero(date.getMinutes());
-  var vSecond = addZero(date.getSeconds());
-  var vMillisecond = padWithZeros(date.getMilliseconds(), 3);
-  var vTimeZone = offset(date);
+  var vHour  = addZero(date.getUTCHours());
+  var vMinute = addZero(date.getUTCMinutes());
+  var vSecond = addZero(date.getUTCSeconds());
+  var vMillisecond = padWithZeros(date.getUTCMilliseconds(), 3);
+  var vTimeZone = offset(timezoneOffset);
   var formatted = format
     .replace(/dd/g, vDay)
     .replace(/MM/g, vMonth)

--- a/lib/date_format.js
+++ b/lib/date_format.js
@@ -44,7 +44,7 @@ exports.asString = function(/*format,*/ date, timezoneOffset) {
   }
   // make the date independent of the system timezone by working with UTC
   if (timezoneOffset === undefined) {
-      timezoneOffset = date.getTimezoneOffset();
+    timezoneOffset = date.getTimezoneOffset();
   }
   date.setUTCMinutes(date.getUTCMinutes() - timezoneOffset);
   var vDay = addZero(date.getUTCDate());
@@ -57,6 +57,7 @@ exports.asString = function(/*format,*/ date, timezoneOffset) {
   var vSecond = addZero(date.getUTCSeconds());
   var vMillisecond = padWithZeros(date.getUTCMilliseconds(), 3);
   var vTimeZone = offset(timezoneOffset);
+  date.setUTCMinutes(date.getUTCMinutes() + timezoneOffset);
   var formatted = format
     .replace(/dd/g, vDay)
     .replace(/MM/g, vMonth)

--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -140,11 +140,12 @@ function messagePassThroughLayout (loggingEvent) {
  * Takes a pattern string, array of tokens and returns a layout function.
  * @param {String} Log format pattern String
  * @param {object} map object of different tokens
+ * @param {number} timezone offset in minutes
  * @return {Function}
  * @author Stephan Strittmatter
  * @author Jan Schmidle
  */
-function patternLayout (pattern, tokens) {
+function patternLayout (pattern, tokens, timezoneOffset) {
   var TTCC_CONVERSION_PATTERN  = "%r %p %c - %m%n";
   var regex = /%(-?[0-9]+)?(\.?[0-9]+)?([\[\]cdhmnprzxy%])(\{([^\}]+)\})?|([^%]+)/;
   
@@ -178,7 +179,7 @@ function patternLayout (pattern, tokens) {
       }
     }
     // Format the date
-    return dateFormat.asString(format, loggingEvent.startTime);
+    return dateFormat.asString(format, loggingEvent.startTime, timezoneOffset);
   }
   
   function hostname() {
@@ -198,7 +199,7 @@ function patternLayout (pattern, tokens) {
   }
 
   function startTime(loggingEvent) {
-    return "" + loggingEvent.startTime.toLocaleTimeString();
+    return dateFormat.asString('hh:mm:ss', loggingEvent.startTime, timezoneOffset);
   }
 
   function startColour(loggingEvent) {

--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -71,11 +71,11 @@ function colorize (str, style) {
   return colorizeStart(style) + str + colorizeEnd(style);
 }
 
-function timestampLevelAndCategory(loggingEvent, colour) {
+function timestampLevelAndCategory(loggingEvent, colour, timezoneOffest) {
   var output = colorize(
     formatLogData(
       '[%s] [%s] %s - '
-      , dateFormat.asString(loggingEvent.startTime)
+      , dateFormat.asString(loggingEvent.startTime, timezoneOffest)
       , loggingEvent.level
       , loggingEvent.categoryName
     )
@@ -93,18 +93,19 @@ function timestampLevelAndCategory(loggingEvent, colour) {
  *
  * @author Stephan Strittmatter
  */
-function basicLayout (loggingEvent) {
-  return timestampLevelAndCategory(loggingEvent) + formatLogData(loggingEvent.data);
+function basicLayout (loggingEvent, timezoneOffset) {
+  return timestampLevelAndCategory(loggingEvent, undefined, timezoneOffset) + formatLogData(loggingEvent.data);
 }
 
 /**
  * colouredLayout - taken from masylum's fork.
  * same as basicLayout, but with colours.
  */
-function colouredLayout (loggingEvent) {
+function colouredLayout (loggingEvent, timezoneOffset) {
   return timestampLevelAndCategory(
     loggingEvent,
-    colours[loggingEvent.level.toString()]
+    colours[loggingEvent.level.toString()],
+    timezoneOffset
   ) + formatLogData(loggingEvent.data);
 }
 

--- a/test/date_format-test.js
+++ b/test/date_format-test.js
@@ -3,11 +3,13 @@ var vows = require('vows')
 , assert = require('assert')
 , dateFormat = require('../lib/date_format');
 
+function createFixedDate() {
+  return new Date(2010, 0, 11, 14, 31, 30, 5);
+}
+
 vows.describe('date_format').addBatch({
   'Date extensions': {
-    topic: function() {
-      return new Date(2010, 0, 11, 14, 31, 30, 5);
-    },
+    topic: createFixedDate,
     'should format a date as string using a pattern': function(date) {
       assert.equal(
         dateFormat.asString(dateFormat.DATETIME_FORMAT, date),
@@ -20,13 +22,16 @@ vows.describe('date_format').addBatch({
         '2010-01-11 14:31:30.005'
       );
     },
-    'should provide a ISO8601 with timezone offset format': function(date) {
+    'should provide a ISO8601 with timezone offset format': function() {
+      var date = createFixedDate();
+      date.setMinutes(date.getMinutes() - date.getTimezoneOffset() - 660);
       date.getTimezoneOffset = function() { return -660; };
       assert.equal(
         dateFormat.asString(dateFormat.ISO8601_WITH_TZ_OFFSET_FORMAT, date),
         "2010-01-11T14:31:30+1100"
       );
-
+      date = createFixedDate();
+      date.setMinutes(date.getMinutes() - date.getTimezoneOffset() + 120);
       date.getTimezoneOffset = function() { return 120; };
       assert.equal(
         dateFormat.asString(dateFormat.ISO8601_WITH_TZ_OFFSET_FORMAT, date),
@@ -40,7 +45,9 @@ vows.describe('date_format').addBatch({
         '14:31:30.005'
       );
     },
-    'should provide a custom format': function(date) {
+    'should provide a custom format': function() {
+      var date = createFixedDate();
+      date.setMinutes(date.getMinutes() - date.getTimezoneOffset() + 120);
       date.getTimezoneOffset = function() { return 120; };
       assert.equal(
         dateFormat.asString("O.SSS.ss.mm.hh.dd.MM.yy", date),

--- a/test/layouts-test.js
+++ b/test/layouts-test.js
@@ -179,7 +179,7 @@ vows.describe('log4js layouts').addBatch({
     topic: function() {
       var event = {
         data: ['this is a test'],
-        startTime: new Date(2010, 11, 5, 14, 18, 30, 45),
+        startTime: new Date('2010-12-05T14:18:30.045Z'), //new Date(2010, 11, 5, 14, 18, 30, 45),
         categoryName: "multiple.levels.of.tests",
         level: {
           toString: function() { return "DEBUG"; }


### PR DESCRIPTION
Often enough remote servers have either diverging or irrelevant timezone settings (from the operation team point of view at least)
In order to display a relevant timestamp in the log, this PR implements an appender-level setting for timezone offset.
The impact is mostly on the prototype of layout that get an extra parameter for timezoneOffset.
The code assumes backward compatible behavior when such configuration is missing.
The following appenders have been modified:
* console
* dateFile
* file
* fileSync
* SMTP
Usage is as simple as adding a timezoneOffset to the appender configuration.
I am not too happy with some workarounds I had to use to get the unit tests to pass, but the original injection of getTimezoneOffset to override the default behavior was pretty hackish from the beginning making it difficult to fiddle with.
I guess a refactor of the timestamp handling to rely completely on UTC up until generating the final timestamp string could be a welcomed improvement.