### PR TITLE
Remove GELF flag when capturing custom fields

### DIFF
--- a/lib/appenders/gelf.js
+++ b/lib/appenders/gelf.js
@@ -85,6 +85,8 @@ function gelfAppender (layout, host, port, hostname, facility) {
     var firstData = data[0];
     
     if (!firstData.GELF) return; // identify with GELF field defined
+    // Remove the GELF key, some gelf supported logging systems drop the message with it
+    delete firstData.GELF;
     Object.keys(firstData).forEach(function(key) {
       // skip _id field for graylog2, skip keys not starts with UNDERSCORE
       if (key.match(/^_/) || key !== "_id") { 

--- a/test/gelfAppender-test.js
+++ b/test/gelfAppender-test.js
@@ -244,6 +244,7 @@ vows.describe('log4js gelfAppender').addBatch({
       },
       'should pick up the options': function(message) {
         assert.equal(message.host, 'cheese');
+        assert.equal(message.GELF, void(0)); // make sure flag was removed
         assert.equal(message._facility, 'nonsense');
         assert.equal(message._every1, 'Hello every one'); // the default value
         assert.equal(message._every2, 'Overwritten!'); // the overwritten value

--- a/test/gelfAppender-test.js
+++ b/test/gelfAppender-test.js
@@ -244,7 +244,7 @@ vows.describe('log4js gelfAppender').addBatch({
       },
       'should pick up the options': function(message) {
         assert.equal(message.host, 'cheese');
-        assert.equal(message.GELF, void(0)); // make sure flag was removed
+        assert.isUndefined(message.GELF); // make sure flag was removed
         assert.equal(message._facility, 'nonsense');
         assert.equal(message._every1, 'Hello every one'); // the default value
         assert.equal(message._every2, 'Overwritten!'); // the overwritten value


### PR DESCRIPTION
While trying to set custom per-message fields via logging with the GELF appender, I noticed that logstash was dropping the message when the GELF flag was set. Still not 100% sure why, but a simple fix for me was to delete the GELF flag after it was checked (seen in this PR), and everything seemed to work happily.

TLDR sort of
* Logstash (which supports GELF) drops messages with the GELF flag present
* There's no particular need to keep this key besides telling the appender to set custom feilds

Hopefully I can merge this in, it seemed like overkill to mimic this appender for logstash with such a minor change. 