### PR TITLE
add protocol and hostname to output format for express

### DIFF
--- a/lib/connect-logger.js
+++ b/lib/connect-logger.js
@@ -128,6 +128,8 @@ function assemble_tokens(req, res, custom_tokens) {
 
   var default_tokens = [];
   default_tokens.push({ token: ':url', replacement: req.originalUrl });
+  default_tokens.push({ token: ':protocol', replacement: req.protocol });
+  default_tokens.push({ token: ':hostname', replacement: req.hostname });
   default_tokens.push({ token: ':method', replacement: req.method });
   default_tokens.push({ token: ':status', replacement: res.__statusCode || res.statusCode });
   default_tokens.push({ token: ':response-time', replacement: res.responseTime });


### PR DESCRIPTION
You can use :protocol and :hostname in express format: 
log4js.connectLogger( log4js.getLogger(), { 
  level: 'auto', 
  format: ':remote-addr - :status - :hostname : :method :url' 
})