### PR TITLE
clustered appender - Unwrap the serialized errors

### DIFF
--- a/lib/appenders/clustered.js
+++ b/lib/appenders/clustered.js
@@ -37,7 +37,14 @@ function deserializeLoggingEvent(loggingEventString) {
 		loggingEvent = JSON.parse(loggingEventString);
 		loggingEvent.startTime = new Date(loggingEvent.startTime);
 		loggingEvent.level = log4js.levels.toLevel(loggingEvent.level.levelStr);
-		
+		// Unwrap serialized errors
+		for (var i = 0; i < loggingEvent.data.length; i++) {
+			var item = loggingEvent.data[i];
+			if (item && item.stack) {
+				loggingEvent.data[i] = item.stack;
+			}
+		}
+
 	} catch (e) {
 		
 		// JSON.parse failed, just log the contents probably a naughty.


### PR DESCRIPTION
When logging an `Error` object using the clustered appender, the logged event is a JSON representation of the error, ex:
[2015-06-09 11:13:48.257] [ERROR] middleware.Security - { stack: 'Error: User is not authorized\n at Object.exec (D:\\Borealis\\demoux\\IMS\\server\\IMS\\middleware\\SecurityCheck\\Instance.js:41:14)\n [...] at applyArgs (D:\\Borealis\\demoux\\IMS\\server\\node_modules\\flow\\flow.js:9:15)\n at Function.flowState (D:\\Borealis\\demoux\\IMS\\server\\node_modules\\flow\\flow.js:39:6)\n at applyArgs (D:\\Borealis\\demoux\\IMS\\server\\node_modules\\flow\\flow.js:9:15)\n at Function.thisFlow.exec (D:\\Borealis\\demoux\\IMS\\server\\node_modules\\flow\\flow.js:94:4)\n at applyArgs (D:\\Borealis\\demoux\\IMS\\server\\node_modules\\flow\\flow.js:9:15)\n at thisFlow (D:\\Borealis\\demoux\\IMS\\server\\node_modules\\flow\\flow.js:15:4)\n at Object.exec (D:\\Borealis\\demoux\\IMS\\server\\node_modules\\flow\\flow.js:103:42)' } 

The error should be formatted identically as with other appenders (e.g. only printing the stack).

This changes adds a check for a `stack` attribute on the serialized loggingEvent and unwraps the errors while deserializing it. Result is:
[2015-06-09 11:13:48.257] [ERROR] middleware.Security - Error: User is not authorized
 at Object.exec (D:\Borealis\demoux\IMS\server\IMS\middleware\SecurityCheck\Instance.js:41:14)
 at applyArgs (D:\Borealis\demoux\IMS\server\node_modules\flow\flow.js:9:15)
 at Function.flowState (D:\Borealis\demoux\IMS\server\node_modules\flow\flow.js:39:6)
 at applyArgs (D:\Borealis\demoux\IMS\server\node_modules\flow\flow.js:9:15)
 at Function.thisFlow.exec (D:\Borealis\demoux\IMS\server\node_modules\flow\flow.js:94:4)
 at applyArgs (D:\Borealis\demoux\IMS\server\node_modules\flow\flow.js:9:15)
 at thisFlow (D:\Borealis\demoux\IMS\server\node_modules\flow\flow.js:15:4)
 at Object.exec (D:\Borealis\demoux\IMS\server\node_modules\flow\flow.js:103:42)