### PR TITLE
Feature - Add support for nodemailer transport plugins

### DIFF
--- a/lib/appenders/smtp.js
+++ b/lib/appenders/smtp.js
@@ -30,7 +30,8 @@ function smtpAppender(config, layout) {
 	function sendBuffer() {
     if (logEventBuffer.length > 0) {
 		
-      var transport = mailer.createTransport(config.SMTP);
+      var transportOpts = getTransportOptions(config);
+      var transport = mailer.createTransport(transportOpts);
       var firstEvent = logEventBuffer[0];
       var body = "";
       var count = logEventBuffer.length;
@@ -70,6 +71,20 @@ function smtpAppender(config, layout) {
 				sendBuffer();
 			}, sendInterval);
     }
+	}
+	
+	function getTransportOptions(config) {
+        var transportOpts = null;
+        if( config.SMTP ) {
+            transportOpts = config.SMTP;
+        } else if( config.transport ) {
+            var plugin = config.transport.plugin || 'smtp';
+            var transportModule = 'nodemailer-' + plugin + '-transport';
+            var transporter = require( transportModule );
+            transportOpts = transporter( config.transport.options );
+        }
+
+        return transportOpts;
 	}
 	
 	return function(loggingEvent) {

--- a/test/smtpAppender-test.js
+++ b/test/smtpAppender-test.js
@@ -38,9 +38,14 @@ function setupLogging(category, options) {
     }
   };
 
+  var fakeTransportPlugin = function () {
+  };
+    
   var smtpModule = sandbox.require('../lib/appenders/smtp', {
 		requires: {
       'nodemailer': fakeMailer,
+      'nodemailer-sendmail-transport': fakeTransportPlugin,
+      'nodemailer-smtp-transport': fakeTransportPlugin,
       '../layouts': fakeLayouts
 		},
     globals: {

--- a/test/smtpAppender-test.js
+++ b/test/smtpAppender-test.js
@@ -222,5 +222,61 @@ vows.describe('log4js smtpAppender').addBatch({
       assert.equal(cons.errors[0].msg, "log4js.smtpAppender - Error happened");
       assert.equal(cons.errors[0].value.message, 'oh noes');
     }
+  },
+  'transport full config': {
+    topic: function() {
+      var setup = setupLogging('transport full config', {
+          recipients: 'recipient@domain.com',
+          transport: {
+              plugin: 'sendmail',
+              options: {
+                  path: '/usr/sbin/sendmail'
+              }
+          }
+      });
+      setup.logger.info('Log event #1');
+      return setup;
+    },
+    'there should be one message only': function (result) {
+      assert.equal(result.results.length, 1);
+    },
+    'message should contain proper data': function (result) {
+      checkMessages(result);
+    }
+  },
+  'transport no-options config': {
+    topic: function() {
+      var setup = setupLogging('transport no-options config', {
+          recipients: 'recipient@domain.com',
+          transport: {
+              plugin: 'sendmail'
+          }
+      });
+      setup.logger.info('Log event #1');
+      return setup;
+    },
+    'there should be one message only': function (result) {
+      assert.equal(result.results.length, 1);
+    },
+    'message should contain proper data': function (result) {
+      checkMessages(result);
+    }
+  },
+  'transport no-plugin config': {
+    topic: function() {
+      var setup = setupLogging('transport no-plugin config', {
+          recipients: 'recipient@domain.com',
+          transport: {
+          }
+      });
+      setup.logger.info('Log event #1');
+      return setup;
+    },
+    'there should be one message only': function (result) {
+      assert.equal(result.results.length, 1);
+    },
+    'message should contain proper data': function (result) {
+      checkMessages(result);
+    }
   }
 }).export(module);


### PR DESCRIPTION
With this change you can use the various nodemailer transport plugins by adding a transport key to your appender config:

```javascript
{
       "appenders": [ {
            "type": "smtp",
            "recipients": "user@domain.com",
            "transport": {
                "plugin": "sendmail",
                "options": {
                    "path": "/usr/sbin/sendmail",
                    "args": [ "-t", "-oi", "-oem" ]
                }
            }
        }]
}
```