### PR TITLE
Add missing category field

### DIFF
--- a/lib/appenders/logstashUDP.js
+++ b/lib/appenders/logstashUDP.js
@@ -21,7 +21,8 @@ function logstashUDP (config, layout) {
       '@timestamp': (new Date(loggingEvent.startTime)).toISOString(),
       type: type,
       message: logMessage,
-      fields: fields
+      fields: fields,
+      category: loggingEvent.logger.category
     };
     sendLog(udp, config.host, config.port, logObject);
   };

--- a/test/logstashUDP-test.js
+++ b/test/logstashUDP-test.js
@@ -42,7 +42,7 @@ function setupLogging(category, options) {
 vows.describe('logstashUDP appender').addBatch({
   'when logging with logstash via UDP': {
     topic: function() {
-      var setup = setupLogging('logstashUDP', {
+      var setup = setupLogging('myCategory', {
         "host": "127.0.0.1",
         "port": 10001,
         "type": "logstashUDP",
@@ -73,6 +73,7 @@ vows.describe('logstashUDP appender').addBatch({
       };
       assert.equal(JSON.stringify(json.fields), JSON.stringify(fields));
       assert.equal(json.message, 'Log event #1');
+      assert.equal(json.category, 'myCategory');
       // Assert timestamp, up to hours resolution.
       var date = new Date(json['@timestamp']);
       assert.equal(


### PR DESCRIPTION
Current logstashUDP appender doesn't send category of the loggingEvent which is very useful when filtering for logs.