### PR TITLE
Patterns to describe caller

### DIFF
--- a/examples/layout.js
+++ b/examples/layout.js
@@ -1,0 +1,64 @@
+var log4js = require('../lib/log4js');
+//log the cheese logger messages to a file, and the console ones as well.
+log4js.configure({
+    appenders: [
+        {
+            type: "file",
+            filename: "cheese.log",
+            category: [ 'cheese','console' ]
+        },
+        {
+            type: "console",
+            layout: {
+                type    : "pattern",
+                pattern : "%[%p {file=%F{2}} /class=%C{1}/ /line=%l/ -%]\t%m"
+            }
+        }
+    ],
+    replaceConsole: true
+});
+
+//to add an appender programmatically, and without clearing other appenders
+//loadAppender is only necessary if you haven't already configured an appender of this type
+log4js.loadAppender('file');
+log4js.addAppender(log4js.appenders.file('pants.log'), 'pants');
+//a custom logger outside of the log4js/lib/appenders directory can be accessed like so
+//log4js.loadAppender('what/you/would/put/in/require');
+//log4js.addAppender(log4js.appenders['what/you/would/put/in/require'](args));
+//or through configure as:
+//log4js.configure({
+//  appenders: [ { type: 'what/you/would/put/in/require', otherArgs: 'blah' } ]
+//});
+
+var logger = log4js.getLogger('cheese');
+//only errors and above get logged.
+//you can also set this log level in the config object
+//via the levels field.
+logger.setLevel('ERROR');
+
+//console logging methods have been replaced with log4js ones.
+//so this will get coloured output on console, and appear in cheese.log
+console.error("AAArgh! Something went wrong", { some: "otherObject", useful_for: "debug purposes" });
+console.log("This should appear as info output");
+
+//these will not appear (logging level beneath error)
+logger.trace('Entering cheese testing');
+logger.debug('Got cheese.');
+logger.info('Cheese is Gouda.');
+logger.log('Something funny about cheese.');
+logger.warn('Cheese is quite smelly.');
+//these end up on the console and in cheese.log
+logger.error('Cheese %s is too ripe!', "gouda");
+logger.fatal('Cheese was breeding ground for listeria.');
+
+//these don't end up in cheese.log, but will appear on the console
+var anotherLogger = log4js.getLogger('another');
+anotherLogger.debug("Just checking");
+
+//one for pants.log
+//will also go to console, since that's configured for all categories
+var pantsLog = log4js.getLogger('pants');
+pantsLog.debug("Something for pants");
+
+
+

--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -2,27 +2,30 @@
 var dateFormat = require('./date_format')
 , os = require('os')
 , eol = os.EOL || '\n'
+, path = require('path')
 , util = require('util')
 , replacementRegExp = /%[sdj]/g
 , layoutMakers = {
-  "messagePassThrough": function() { return messagePassThroughLayout; }, 
-  "basic": function() { return basicLayout; }, 
-  "colored": function() { return colouredLayout; }, 
-  "coloured": function() { return colouredLayout; }, 
+  "messagePassThrough": function() { return messagePassThroughLayout; },
+  "basic": function() { return basicLayout; },
+  "colored": function() { return colouredLayout; },
+  "coloured": function() { return colouredLayout; },
   "pattern": function (config) {
     return patternLayout(config && config.pattern, config && config.tokens);
 	}
 }
 , colours = {
-  ALL: "grey", 
-  TRACE: "blue", 
-  DEBUG: "cyan", 
-  INFO: "green", 
-  WARN: "yellow", 
-  ERROR: "red", 
-  FATAL: "magenta", 
+  ALL: "grey",
+  TRACE: "blue",
+  DEBUG: "cyan",
+  INFO: "green",
+  WARN: "yellow",
+  ERROR: "red",
+  FATAL: "magenta",
   OFF: "grey"
-};
+}
+, ERROR_STACK_CLIP = 7
+;
 
 function wrapErrorsWithInspect(items) {
   return items.map(function(item) {
@@ -121,16 +124,19 @@ function messagePassThroughLayout (loggingEvent) {
  *  - %r time in toLocaleTimeString format
  *  - %p log level
  *  - %c log category
+ *  - %C fully-qualified class name - %F{n} for the last n parts
+ *  - %F filename - %F{n} for the last n parts
  *  - %h hostname
+ *  - %l line number
  *  - %m log data
  *  - %d date in various formats
- *  - %% %
+ *  - %% % (literal percentage sign)
  *  - %n newline
  *  - %z pid
  *  - %x{<tokenname>} add dynamic tokens to your log. Tokens are specified in the tokens parameter
  * You can use %[ and %] to define a colored block.
  *
- * Tokens are specified as simple key:value objects. 
+ * Tokens are specified as simple key:value objects.
  * The key represents the token name whereas the value can be a string or function
  * which is called to extract the value to put in the log message. If token is not
  * found, it doesn't replace the field.
@@ -147,19 +153,50 @@ function messagePassThroughLayout (loggingEvent) {
  */
 function patternLayout (pattern, tokens, timezoneOffset) {
   var TTCC_CONVERSION_PATTERN  = "%r %p %c - %m%n";
-  var regex = /%(-?[0-9]+)?(\.?[0-9]+)?([\[\]cdhmnprzxy%])(\{([^\}]+)\})?|([^%]+)/;
-  
+  var regex = /%(-?[0-9]+)?(\.?[0-9]+)?([\[\]CcdFhlmnprzxy%])(\{([^\}]+)\})?|([^%]+)/;
+
   pattern = pattern || TTCC_CONVERSION_PATTERN;
+
+  // Lee
+  function className(loggingEvent, specifier) {
+    var str = loggingEvent.callStack[ loggingEvent.callStack.length - ERROR_STACK_CLIP]
+      .replace(/^\s+at\s+(\S+).*$/, function (){
+        return arguments[1];
+    });
+    str = _parts(str, '.', specifier );
+    return str;
+  }
+
+  function lineNumber(loggingEvent, specifier) {
+    return loggingEvent.callStack[ loggingEvent.callStack.length - ERROR_STACK_CLIP]
+      .replace(/^.+?:(\d+):\d+\)$/, function (){
+        return arguments[1];
+      });
+  }
+
+  function fileName(loggingEvent, specifier) {
+    var str = loggingEvent.callStack[ loggingEvent.callStack.length - ERROR_STACK_CLIP]
+      .replace(/^.+?\(([^\)]+):\d+:\d+\)$/, function (){
+        return arguments[1];
+      });
+    str = _parts(str, path.sep, specifier );
+    return str;
+  }
+
+  function _parts(str, sep, specifier){
+    if (specifier) {
+      var precision = parseInt(specifier, 10);
+      var parts = str.split(sep);
+      if (precision < parts.length) {
+        str = parts.slice(parts.length - precision).join(sep);
+      }
+    }
+    return str;
+  }
 
   function categoryName(loggingEvent, specifier) {
     var loggerName = loggingEvent.categoryName;
-    if (specifier) {
-      var precision = parseInt(specifier, 10);
-      var loggerNameBits = loggerName.split(".");
-      if (precision < loggerNameBits.length) {
-        loggerName = loggerNameBits.slice(loggerNameBits.length - precision).join(".");
-      }
-    }
+    loggerName = _parts(loggerName, '.', specifier);
     return loggerName;
   }
 
@@ -171,7 +208,7 @@ function patternLayout (pattern, tokens, timezoneOffset) {
       if (format == "ISO8601") {
         format = dateFormat.ISO8601_FORMAT;
       } else if (format == "ISO8601_WITH_TZ_OFFSET") {
-        format = dateFormat.ISO8601_WITH_TZ_OFFSET_FORMAT; 
+        format = dateFormat.ISO8601_WITH_TZ_OFFSET_FORMAT;
       } else if (format == "ABSOLUTE") {
         format = dateFormat.ABSOLUTETIME_FORMAT;
       } else if (format == "DATE") {
@@ -181,7 +218,7 @@ function patternLayout (pattern, tokens, timezoneOffset) {
     // Format the date
     return dateFormat.asString(format, loggingEvent.startTime, timezoneOffset);
   }
-  
+
   function hostname() {
     return os.hostname().toString();
   }
@@ -189,7 +226,7 @@ function patternLayout (pattern, tokens, timezoneOffset) {
   function formatMessage(loggingEvent) {
     return formatLogData(loggingEvent.data);
   }
-  
+
   function endOfLine() {
     return eol;
   }
@@ -221,7 +258,7 @@ function patternLayout (pattern, tokens, timezoneOffset) {
       return process.pid;
     }
   }
-  
+
   function clusterInfo(loggingEvent, specifier) {
     if (loggingEvent.cluster && specifier) {
       return specifier
@@ -248,8 +285,11 @@ function patternLayout (pattern, tokens, timezoneOffset) {
 
   var replacers = {
     'c': categoryName,
+    'C': className,
     'd': formatAsDate,
+    'F': fileName,
     'h': hostname,
+    'l': lineNumber,
     'm': formatMessage,
     'n': endOfLine,
     'p': logLevel,
@@ -295,12 +335,12 @@ function patternLayout (pattern, tokens, timezoneOffset) {
     }
     return toPad;
   }
-  
+
   return function(loggingEvent) {
     var formattedString = "";
     var result;
     var searchString = pattern;
-    
+
     while ((result = regex.exec(searchString))) {
       var matchedString = result[0];
       var padding = result[1];
@@ -308,7 +348,7 @@ function patternLayout (pattern, tokens, timezoneOffset) {
       var conversionCharacter = result[3];
       var specifier = result[5];
       var text = result[6];
-      
+
       // Check if the pattern matched was just normal text
       if (text) {
         formattedString += "" + text;
@@ -331,11 +371,11 @@ function patternLayout (pattern, tokens, timezoneOffset) {
 }
 
 module.exports = {
-  basicLayout: basicLayout, 
-  messagePassThroughLayout: messagePassThroughLayout, 
-  patternLayout: patternLayout, 
-  colouredLayout: colouredLayout, 
-  coloredLayout: colouredLayout, 
+  basicLayout: basicLayout,
+  messagePassThroughLayout: messagePassThroughLayout,
+  patternLayout: patternLayout,
+  colouredLayout: colouredLayout,
+  coloredLayout: colouredLayout,
   addLayout: function(name, serializerGenerator) {
     layoutMakers[name] = serializerGenerator;
   },

--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -141,7 +141,7 @@ function messagePassThroughLayout (loggingEvent) {
  * which is called to extract the value to put in the log message. If token is not
  * found, it doesn't replace the field.
  *
- * A sample token would be: { "pid" : function() { return process.pid; } }
+ * A sample token: { "pid" : function() { return process.pid; } }
  *
  * Takes a pattern string, array of tokens and returns a layout function.
  * @param {String} Log format pattern String
@@ -150,6 +150,7 @@ function messagePassThroughLayout (loggingEvent) {
  * @return {Function}
  * @author Stephan Strittmatter
  * @author Jan Schmidle
+ * @author Lee Goddard
  */
 function patternLayout (pattern, tokens, timezoneOffset) {
   var TTCC_CONVERSION_PATTERN  = "%r %p %c - %m%n";
@@ -157,7 +158,6 @@ function patternLayout (pattern, tokens, timezoneOffset) {
 
   pattern = pattern || TTCC_CONVERSION_PATTERN;
 
-  // Lee
   function className(loggingEvent, specifier) {
     var str = loggingEvent.callStack[ loggingEvent.callStack.length - ERROR_STACK_CLIP]
       .replace(/^\s+at\s+(\S+).*$/, function (){

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -16,6 +16,7 @@ var logWritesEnabled = true;
  * @author Seth Chisamore
  */
 function LoggingEvent (categoryName, level, data, logger) {
+  this.callStack = (new Error).stack.split("\n");
   this.startTime = new Date();
   this.categoryName = categoryName;
   this.data = data;
@@ -32,7 +33,7 @@ function LoggingEvent (categoryName, level, data, logger) {
  */
 function Logger (name, level) {
   this.category = name || DEFAULT_CATEGORY;
-  
+
   if (level) {
     this.setLevel(level);
   }
@@ -69,7 +70,7 @@ Logger.prototype.isLevelEnabled = function(otherLevel) {
     Logger.prototype['is'+levelString+'Enabled'] = function() {
       return this.isLevelEnabled(level);
     };
-    
+
     Logger.prototype[levelString.toLowerCase()] = function () {
       if (logWritesEnabled && this.isLevelEnabled(level)) {
         var args = Array.prototype.slice.call(arguments);

--- a/test/layouts-test.js
+++ b/test/layouts-test.js
@@ -290,13 +290,18 @@ vows.describe('log4js layouts').addBatch({
     '%x should output the string stored in tokens': function(args) {
       test(args, '%x', 'null');
     },
-    // Lee
-    '%C should output the fully-qualified class name': function(args) {
-      test(args, '%C', 'xxx');
-    }
-    '%l should output the line number': function(args) {
-      test(args, '%l', 'xxx');
-    }
+    // Lee: cannot test logger.callStack like this
+    // and mocking makes no sense, as it changes the
+    // size of the stack/call depth.
+    // '%C should output the fully-qualified class name': function(args) {
+    //   test(args, '%C', 'xxx');
+    // },
+    // '%l should output the line number': function(args) {
+    //   test(args, '%l', 'xxx');
+    // },
+    // '%f should output the file name': function(args) {
+    //   test(args, '%f', 'xxx');
+    // }
   },
   'layout makers': {
     topic: require('../lib/layouts'),

--- a/test/layouts-test.js
+++ b/test/layouts-test.js
@@ -289,6 +289,13 @@ vows.describe('log4js layouts').addBatch({
     },
     '%x should output the string stored in tokens': function(args) {
       test(args, '%x', 'null');
+    },
+    // Lee
+    '%C should output the fully-qualified class name': function(args) {
+      test(args, '%C', 'xxx');
+    }
+    '%l should output the line number': function(args) {
+      test(args, '%l', 'xxx');
     }
   },
   'layout makers': {


### PR DESCRIPTION
Hi
Had a go at adding support for Log4j's `%l`, `%C`, and `%f` (line, class, filename).
This relies upon a change in `logger` to set once the call stack, but I have not yet found a good way to test this. 
Do you have any ideas?
The code is only an hour or so old, so needs testing.
TIA
Lee