### PR TITLE
Send a remaining logs email when shutdown is called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 build
 node_modules
 .bob/
-test/streams/test-rolling*
+test/streams/test-*
 .idea

--- a/lib/appenders/smtp.js
+++ b/lib/appenders/smtp.js
@@ -1,120 +1,122 @@
 "use strict";
 var layouts = require("../layouts")
-, mailer = require("nodemailer")
-, os = require('os')
-, async = require('async')
-, unsentCount = 0
-, shutdownTimeout;
+        , mailer = require("nodemailer")
+        , os = require('os')
+        , async = require('async')
+        , unsentCount = 0
+        , shutdownTimeout;
 
 /**
-* SMTP Appender. Sends logging events using SMTP protocol. 
-* It can either send an email on each event or group several 
-* logging events gathered during specified interval.
-*
-* @param config appender configuration data
-*    config.sendInterval time between log emails (in seconds), if 0
-*    then every event sends an email
-*    config.shutdownTimeout time to give up remaining emails (in seconds; defaults to 5).
-* @param layout a function that takes a logevent and returns a string (defaults to basicLayout).
-*/
+ * SMTP Appender. Sends logging events using SMTP protocol. 
+ * It can either send an email on each event or group several 
+ * logging events gathered during specified interval.
+ *
+ * @param config appender configuration data
+ *    config.sendInterval time between log emails (in seconds), if 0
+ *    then every event sends an email
+ *    config.shutdownTimeout time to give up remaining emails (in seconds; defaults to 5).
+ * @param layout a function that takes a logevent and returns a string (defaults to basicLayout).
+ */
 function smtpAppender(config, layout) {
-	layout = layout || layouts.basicLayout;
-	var subjectLayout = layouts.messagePassThroughLayout;
-	var sendInterval = config.sendInterval*1000 || 0;
-	
-	var logEventBuffer = [];
-	var sendTimer;
-	
-	shutdownTimeout = ('shutdownTimeout' in config ? config.shutdownTimeout : 5) * 1000;
-	
-	function sendBuffer() {
-    if (logEventBuffer.length > 0) {
-		
-      var transportOpts = getTransportOptions(config);
-      var transport = mailer.createTransport(transportOpts);
-      var firstEvent = logEventBuffer[0];
-      var body = "";
-      var count = logEventBuffer.length;
-      while (logEventBuffer.length > 0) {
-        body += layout(logEventBuffer.shift(), config.timezoneOffset) + "\n";
-      }
+    layout = layout || layouts.basicLayout;
+    var subjectLayout = layouts.messagePassThroughLayout;
+    var sendInterval = config.sendInterval * 1000 || 0;
 
-      var msg = {
-        to: config.recipients,
-        subject: config.subject || subjectLayout(firstEvent),
-        headers: { "Hostname": os.hostname() }
-      };
-	  
-      if (!config.html) {
-	msg.text = body;
-      } else {
-    	msg.html = body;
-      }
-      
-      if (config.sender) {
-        msg.from = config.sender;
-      }
-      transport.sendMail(msg, function(error, success) {
-        if (error) {
-          console.error("log4js.smtpAppender - Error happened", error);
+    var logEventBuffer = [];
+    var sendTimer;
+
+    shutdownTimeout = ('shutdownTimeout' in config ? config.shutdownTimeout : 5) * 1000;
+
+    function sendBuffer() {
+        if (logEventBuffer.length > 0) {
+
+            var transportOpts = getTransportOptions(config);
+            var transport = mailer.createTransport(transportOpts);
+            var firstEvent = logEventBuffer[0];
+            var body = "";
+            var count = logEventBuffer.length;
+            while (logEventBuffer.length > 0) {
+                body += layout(logEventBuffer.shift(), config.timezoneOffset) + "\n";
+            }
+
+            var msg = {
+                to: config.recipients,
+                subject: config.subject || subjectLayout(firstEvent),
+                headers: {"Hostname": os.hostname()}
+            };
+
+            if (!config.html) {
+                msg.text = body;
+            } else {
+                msg.html = body;
+            }
+
+            if (config.sender) {
+                msg.from = config.sender;
+            }
+            transport.sendMail(msg, function (error, success) {
+                if (error) {
+                    console.error("log4js.smtpAppender - Error happened", error);
+                }
+                transport.close();
+                unsentCount -= count;
+            });
         }
-        transport.close();
-        unsentCount -= count;
-      });
     }
-	}
-	
-	function scheduleSend() {
-		if (!sendTimer) {
-			sendTimer = setTimeout(function() {
-				sendTimer = null; 
-				sendBuffer();
-			}, sendInterval);
+
+    function scheduleSend() {
+        if (!sendTimer) {
+            sendTimer = setTimeout(function () {
+                sendTimer = null;
+                sendBuffer();
+            }, sendInterval);
+        }
     }
-	}
-	
-	function getTransportOptions(config) {
+
+    function getTransportOptions(config) {
         var transportOpts = null;
-        if( config.SMTP ) {
+        if (config.SMTP) {
             transportOpts = config.SMTP;
-        } else if( config.transport ) {
+        } else if (config.transport) {
             var plugin = config.transport.plugin || 'smtp';
             var transportModule = 'nodemailer-' + plugin + '-transport';
-            var transporter = require( transportModule );
-            transportOpts = transporter( config.transport.options );
+            var transporter = require(transportModule);
+            transportOpts = transporter(config.transport.options);
         }
 
         return transportOpts;
-	}
-	
-	return function(loggingEvent) {
-		unsentCount++;
-		logEventBuffer.push(loggingEvent);
-		if (sendInterval > 0) {
-			scheduleSend();
-		} else {
-			sendBuffer();
     }
-	};
+
+    return function (loggingEvent) {
+        unsentCount++;
+        logEventBuffer.push(loggingEvent);
+        if (sendInterval > 0) {
+            scheduleSend();
+        } else {
+            sendBuffer();
+        }
+    };
 }
 
 function configure(config) {
-	var layout;
-	if (config.layout) {
-		layout = layouts.layout(config.layout.type, config.layout);
-	}
-	return smtpAppender(config, layout);
+    var layout;
+    if (config.layout) {
+        layout = layouts.layout(config.layout.type, config.layout);
+    }
+    return smtpAppender(config, layout);
 }
 
 function shutdown(cb) {
-	if (shutdownTimeout > 0) {
-		setTimeout(function() { unsentCount = 0; }, shutdownTimeout);
-	}
-	async.whilst(function() {
-		return unsentCount > 0;
-	}, function(done) {
-		setTimeout(done, 100);
-	}, cb);
+    if (shutdownTimeout > 0) {
+        setTimeout(function () {
+            unsentCount = 0;
+        }, shutdownTimeout);
+    }
+    async.whilst(function () {
+        return unsentCount > 0;
+    }, function (done) {
+        setTimeout(done, 100);
+    }, cb);
 }
 
 exports.name = "smtp";

--- a/lib/appenders/smtp.js
+++ b/lib/appenders/smtp.js
@@ -1,10 +1,81 @@
 "use strict";
-var layouts = require("../layouts")
-        , mailer = require("nodemailer")
-        , os = require('os')
-        , async = require('async')
-        , unsentCount = 0
-        , shutdownTimeout;
+
+var layouts = require("../layouts");
+var mailer = require("nodemailer");
+var os = require('os');
+var async = require('async');
+
+var logEventBuffer = [];
+var subjectLayout;
+var layout;
+
+var unsentCount = 0;
+var shutdownTimeout;
+
+var sendInterval;
+var sendTimer;
+
+var config;
+
+function sendBuffer() {
+    if (logEventBuffer.length > 0) {
+
+        var transportOpts = getTransportOptions(config);
+        var transport = mailer.createTransport(transportOpts);
+        var firstEvent = logEventBuffer[0];
+        var body = "";
+        var count = logEventBuffer.length;
+        while (logEventBuffer.length > 0) {
+            body += layout(logEventBuffer.shift(), config.timezoneOffset) + "\n";
+        }
+
+        var msg = {
+            to: config.recipients,
+            subject: config.subject || subjectLayout(firstEvent),
+            headers: {"Hostname": os.hostname()}
+        };
+
+        if (!config.html) {
+            msg.text = body;
+        } else {
+            msg.html = body;
+        }
+
+        if (config.sender) {
+            msg.from = config.sender;
+        }
+        transport.sendMail(msg, function (error) {
+            if (error) {
+                console.error("log4js.smtpAppender - Error happened", error);
+            }
+            transport.close();
+            unsentCount -= count;
+        });
+    }
+}
+
+function getTransportOptions() {
+    var transportOpts = null;
+    if (config.SMTP) {
+        transportOpts = config.SMTP;
+    } else if (config.transport) {
+        var plugin = config.transport.plugin || 'smtp';
+        var transportModule = 'nodemailer-' + plugin + '-transport';
+        var transporter = require(transportModule);
+        transportOpts = transporter(config.transport.options);
+    }
+
+    return transportOpts;
+}
+
+function scheduleSend() {
+    if (!sendTimer) {
+        sendTimer = setTimeout(function () {
+            sendTimer = null;
+            sendBuffer();
+        }, sendInterval);
+    }
+}
 
 /**
  * SMTP Appender. Sends logging events using SMTP protocol. 
@@ -15,78 +86,16 @@ var layouts = require("../layouts")
  *    config.sendInterval time between log emails (in seconds), if 0
  *    then every event sends an email
  *    config.shutdownTimeout time to give up remaining emails (in seconds; defaults to 5).
- * @param layout a function that takes a logevent and returns a string (defaults to basicLayout).
+ * @param _layout a function that takes a logevent and returns a string (defaults to basicLayout).
  */
-function smtpAppender(config, layout) {
-    layout = layout || layouts.basicLayout;
-    var subjectLayout = layouts.messagePassThroughLayout;
-    var sendInterval = config.sendInterval * 1000 || 0;
-
-    var logEventBuffer = [];
-    var sendTimer;
-
+function smtpAppender(_config, _layout) {
+    config = _config;
+    layout = _layout || layouts.basicLayout;
+    subjectLayout = layouts.messagePassThroughLayout;
+    sendInterval = config.sendInterval * 1000 || 0;
+    
     shutdownTimeout = ('shutdownTimeout' in config ? config.shutdownTimeout : 5) * 1000;
-
-    function sendBuffer() {
-        if (logEventBuffer.length > 0) {
-
-            var transportOpts = getTransportOptions(config);
-            var transport = mailer.createTransport(transportOpts);
-            var firstEvent = logEventBuffer[0];
-            var body = "";
-            var count = logEventBuffer.length;
-            while (logEventBuffer.length > 0) {
-                body += layout(logEventBuffer.shift(), config.timezoneOffset) + "\n";
-            }
-
-            var msg = {
-                to: config.recipients,
-                subject: config.subject || subjectLayout(firstEvent),
-                headers: {"Hostname": os.hostname()}
-            };
-
-            if (!config.html) {
-                msg.text = body;
-            } else {
-                msg.html = body;
-            }
-
-            if (config.sender) {
-                msg.from = config.sender;
-            }
-            transport.sendMail(msg, function (error, success) {
-                if (error) {
-                    console.error("log4js.smtpAppender - Error happened", error);
-                }
-                transport.close();
-                unsentCount -= count;
-            });
-        }
-    }
-
-    function scheduleSend() {
-        if (!sendTimer) {
-            sendTimer = setTimeout(function () {
-                sendTimer = null;
-                sendBuffer();
-            }, sendInterval);
-        }
-    }
-
-    function getTransportOptions(config) {
-        var transportOpts = null;
-        if (config.SMTP) {
-            transportOpts = config.SMTP;
-        } else if (config.transport) {
-            var plugin = config.transport.plugin || 'smtp';
-            var transportModule = 'nodemailer-' + plugin + '-transport';
-            var transporter = require(transportModule);
-            transportOpts = transporter(config.transport.options);
-        }
-
-        return transportOpts;
-    }
-
+    
     return function (loggingEvent) {
         unsentCount++;
         logEventBuffer.push(loggingEvent);
@@ -98,18 +107,19 @@ function smtpAppender(config, layout) {
     };
 }
 
-function configure(config) {
-    var layout;
-    if (config.layout) {
-        layout = layouts.layout(config.layout.type, config.layout);
+function configure(_config) {
+    config = _config;
+    if (_config.layout) {
+        layout = layouts.layout(_config.layout.type, _config.layout);
     }
-    return smtpAppender(config, layout);
+    return smtpAppender(_config, layout);
 }
 
 function shutdown(cb) {
     if (shutdownTimeout > 0) {
         setTimeout(function () {
-            unsentCount = 0;
+            if(sendTimer) clearTimeout(sendTimer);
+            sendBuffer();
         }, shutdownTimeout);
     }
     async.whilst(function () {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=0.8"
   },
   "scripts": {
-    "test": "vows"
+    "test": "vows --spec"
   },
   "directories": {
     "test": "test",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "node": ">=0.8"
   },
   "scripts": {
-    "test": "vows --spec"
+    "test": "vows --spec",
+    "lint": "jshint lib test"
   },
   "directories": {
     "test": "test",
@@ -35,9 +36,10 @@
     "underscore": "1.8.2"
   },
   "devDependencies": {
-    "vows": "0.7.0",
+    "jshint": "2.9.0",
     "sandboxed-module": "0.1.3",
-    "underscore": "1.2.1"
+    "underscore": "1.2.1",
+    "vows": "0.7.0"
   },
   "browser": {
     "os": false

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "node": ">=0.8"
   },
   "scripts": {
-    "test": "vows --spec",
-    "lint": "jshint lib test"
+    "test": "vows --spec"
   },
   "directories": {
     "test": "test",
@@ -36,7 +35,6 @@
     "underscore": "1.8.2"
   },
   "devDependencies": {
-    "jshint": "2.9.1-rc1",
     "sandboxed-module": "0.1.3",
     "underscore": "1.2.1",
     "vows": "0.7.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "underscore": "1.8.2"
   },
   "devDependencies": {
-    "jshint": "2.9.0",
+    "jshint": "2.9.1-rc1",
     "sandboxed-module": "0.1.3",
     "underscore": "1.2.1",
     "vows": "0.7.0"

--- a/test/smtpAppender-test.js
+++ b/test/smtpAppender-test.js
@@ -1,287 +1,288 @@
 "use strict";
-var vows = require('vows')
-, assert = require('assert')
-, log4js = require('../lib/log4js')
-, sandbox = require('sandboxed-module')
-;
+var vows = require('vows');
+var assert = require('assert');
+var log4js = require('../lib/log4js');
+var sandbox = require('sandboxed-module');
 
 function setupLogging(category, options) {
-  var msgs = [];
+    var msgs = [];
 
-  var fakeMailer = {
-		createTransport: function (name, options) {
-			return {
-				config: options,
-				sendMail: function (msg, callback) {
-          msgs.push(msg);
-          callback(null, true);
+    var fakeMailer = {
+        createTransport: function (name, options) {
+            return {
+                config: options,
+                sendMail: function (msg, callback) {
+                    msgs.push(msg);
+                    callback(null, true);
+                },
+                close: function () {
+                }
+            };
+        }
+    };
+
+    var fakeLayouts = {
+        layout: function (type, config) {
+            this.type = type;
+            this.config = config;
+            return log4js.layouts.messagePassThroughLayout;
         },
-        close: function() {}
-			};
-		}
-  };
+        basicLayout: log4js.layouts.basicLayout,
+        messagePassThroughLayout: log4js.layouts.messagePassThroughLayout
+    };
 
-  var fakeLayouts = {
-    layout: function(type, config) {
-      this.type = type;
-      this.config = config;
-      return log4js.layouts.messagePassThroughLayout;
-    },
-    basicLayout: log4js.layouts.basicLayout,
-    messagePassThroughLayout: log4js.layouts.messagePassThroughLayout
-  };
+    var fakeConsole = {
+        errors: [],
+        error: function (msg, value) {
+            this.errors.push({msg: msg, value: value});
+        }
+    };
 
-  var fakeConsole = {
-    errors: [],
-    error: function(msg, value) {
-      this.errors.push({ msg: msg, value: value });
-    }
-  };
+    var fakeTransportPlugin = function () {
+    };
 
-  var fakeTransportPlugin = function () {
-  };
-    
-  var smtpModule = sandbox.require('../lib/appenders/smtp', {
-		requires: {
-      'nodemailer': fakeMailer,
-      'nodemailer-sendmail-transport': fakeTransportPlugin,
-      'nodemailer-smtp-transport': fakeTransportPlugin,
-      '../layouts': fakeLayouts
-		},
-    globals: {
-      console: fakeConsole
-    }
-  });
+    var smtpModule = sandbox.require('../lib/appenders/smtp', {
+        requires: {
+            'nodemailer': fakeMailer,
+            'nodemailer-sendmail-transport': fakeTransportPlugin,
+            'nodemailer-smtp-transport': fakeTransportPlugin,
+            '../layouts': fakeLayouts
+        },
+        globals: {
+            console: fakeConsole
+        }
+    });
 
-  log4js.addAppender(smtpModule.configure(options), category);
+    log4js.addAppender(smtpModule.configure(options), category);
 
-  return {
-		logger: log4js.getLogger(category),
-		mailer: fakeMailer,
-    layouts: fakeLayouts,
-    console: fakeConsole,
-		results: msgs
-  };
+    return {
+        logger: log4js.getLogger(category),
+        mailer: fakeMailer,
+        layouts: fakeLayouts,
+        console: fakeConsole,
+        results: msgs
+    };
 }
 
-function checkMessages (result, sender, subject) {
-  for (var i = 0; i < result.results.length; ++i) {
-		assert.equal(result.results[i].from, sender);
-		assert.equal(result.results[i].to, 'recipient@domain.com');
-		assert.equal(result.results[i].subject, subject ? subject : 'Log event #' + (i+1));
-		assert.ok(new RegExp('.+Log event #' + (i+1) + '\n$').test(result.results[i].text));
-  }
+function checkMessages(result, sender, subject) {
+    for (var i = 0; i < result.results.length; ++i) {
+        assert.equal(result.results[i].from, sender);
+        assert.equal(result.results[i].to, 'recipient@domain.com');
+        assert.equal(result.results[i].subject, subject ? subject : 'Log event #' + (i + 1));
+        assert.ok(new RegExp('.+Log event #' + (i + 1) + '\n$').test(result.results[i].text));
+    }
 }
 
 log4js.clearAppenders();
 vows.describe('log4js smtpAppender').addBatch({
-  'minimal config': {
-		topic: function() {
-      var setup = setupLogging('minimal config', {
-        recipients: 'recipient@domain.com',
-        SMTP: {
-          port: 25,
-          auth: {
-            user: 'user@domain.com'
-          }
+    'minimal config': {
+        topic: function () {
+            var setup = setupLogging('minimal config', {
+                recipients: 'recipient@domain.com',
+                SMTP: {
+                    port: 25,
+                    auth: {
+                        user: 'user@domain.com'
+                    }
+                }
+            });
+            setup.logger.info('Log event #1');
+            return setup;
+        },
+        'there should be one message only': function (result) {
+            assert.equal(result.results.length, 1);
+        },
+        'message should contain proper data': function (result) {
+            checkMessages(result);
         }
-      });
-      setup.logger.info('Log event #1');
-      return setup;
-		},
-		'there should be one message only': function (result) {
-      assert.equal(result.results.length, 1);
-		},
-		'message should contain proper data': function (result) {
-      checkMessages(result);
-		}
-  },
-  'fancy config': {
-    topic: function() {
-      var setup = setupLogging('fancy config', {
-        recipients: 'recipient@domain.com',
-        sender: 'sender@domain.com',
-        subject: 'This is subject',
-        SMTP: {
-          port: 25,
-          auth: {
-            user: 'user@domain.com'
-          }
+    },
+    'fancy config': {
+        topic: function () {
+            var setup = setupLogging('fancy config', {
+                recipients: 'recipient@domain.com',
+                sender: 'sender@domain.com',
+                subject: 'This is subject',
+                SMTP: {
+                    port: 25,
+                    auth: {
+                        user: 'user@domain.com'
+                    }
+                }
+            });
+            setup.logger.info('Log event #1');
+            return setup;
+        },
+        'there should be one message only': function (result) {
+            assert.equal(result.results.length, 1);
+        },
+        'message should contain proper data': function (result) {
+            checkMessages(result, 'sender@domain.com', 'This is subject');
         }
-      });
-      setup.logger.info('Log event #1');
-      return setup;
     },
-    'there should be one message only': function (result) {
-      assert.equal(result.results.length, 1);
-    },
-    'message should contain proper data': function (result) {
-      checkMessages(result, 'sender@domain.com', 'This is subject');
-    }
-  },
-  'config with layout': {
-    topic: function() {
-      var setup = setupLogging('config with layout', {
-        layout: {
-          type: "tester"
+    'config with layout': {
+        topic: function () {
+            var setup = setupLogging('config with layout', {
+                layout: {
+                    type: "tester"
+                }
+            });
+            return setup;
+        },
+        'should configure layout': function (result) {
+            assert.equal(result.layouts.type, 'tester');
         }
-      });
-      return setup;
     },
-    'should configure layout': function(result) {
-      assert.equal(result.layouts.type, 'tester');
-    }
-  },
-  'separate email for each event': {
-    topic: function() {
-      var self = this;
-      var setup = setupLogging('separate email for each event', {
-        recipients: 'recipient@domain.com',
-        SMTP: {
-          port: 25,
-          auth: {
-            user: 'user@domain.com'
-          }
+    'separate email for each event': {
+        topic: function () {
+            var self = this;
+            var setup = setupLogging('separate email for each event', {
+                recipients: 'recipient@domain.com',
+                SMTP: {
+                    port: 25,
+                    auth: {
+                        user: 'user@domain.com'
+                    }
+                }
+            });
+            setTimeout(function () {
+                setup.logger.info('Log event #1');
+            }, 0);
+            setTimeout(function () {
+                setup.logger.info('Log event #2');
+            }, 500);
+            setTimeout(function () {
+                setup.logger.info('Log event #3');
+            }, 1100);
+            setTimeout(function () {
+                self.callback(null, setup);
+            }, 3000);
+        },
+        'there should be three messages': function (result) {
+            assert.equal(result.results.length, 3);
+        },
+        'messages should contain proper data': function (result) {
+            checkMessages(result);
         }
-      });
-      setTimeout(function () {
-        setup.logger.info('Log event #1');
-      }, 0);
-      setTimeout(function () {
-        setup.logger.info('Log event #2');
-      }, 500);
-      setTimeout(function () {
-        setup.logger.info('Log event #3');
-      }, 1100);
-      setTimeout(function () {
-        self.callback(null, setup);
-      }, 3000);
     },
-    'there should be three messages': function (result) {
-      assert.equal(result.results.length, 3);
-    },
-    'messages should contain proper data': function (result) {
-      checkMessages(result);
-    }
-  },
-  'multiple events in one email': {
-    topic: function() {
-      var self = this;
-      var setup = setupLogging('multiple events in one email', {
-        recipients: 'recipient@domain.com',
-        sendInterval: 1,
-        SMTP: {
-          port: 25,
-          auth: {
-            user: 'user@domain.com'
-          }
+    'multiple events in one email': {
+        topic: function () {
+            var self = this;
+            var setup = setupLogging('multiple events in one email', {
+                recipients: 'recipient@domain.com',
+                sendInterval: 1,
+                SMTP: {
+                    port: 25,
+                    auth: {
+                        user: 'user@domain.com'
+                    }
+                }
+            });
+            setTimeout(function () {
+                setup.logger.info('Log event #1');
+            }, 0);
+            setTimeout(function () {
+                setup.logger.info('Log event #2');
+            }, 100);
+            setTimeout(function () {
+                setup.logger.info('Log event #3');
+            }, 1500);
+            setTimeout(function () {
+                self.callback(null, setup);
+            }, 3000);
+        },
+        'there should be two messages': function (result) {
+            assert.equal(result.results.length, 2);
+        },
+        'messages should contain proper data': function (result) {
+            assert.equal(result.results[0].to, 'recipient@domain.com');
+            assert.equal(result.results[0].subject, 'Log event #1');
+            assert.equal(result.results[0].text.match(new RegExp('.+Log event #[1-2]$', 'gm')).length, 2);
+            assert.equal(result.results[1].to, 'recipient@domain.com');
+            assert.equal(result.results[1].subject, 'Log event #3');
+            assert.ok(new RegExp('.+Log event #3\n$').test(result.results[1].text));
         }
-      });
-      setTimeout(function () {
-        setup.logger.info('Log event #1');
-      }, 0);
-      setTimeout(function () {
-        setup.logger.info('Log event #2');
-      }, 100);
-      setTimeout(function () {
-        setup.logger.info('Log event #3');
-      }, 1500);
-      setTimeout(function () {
-        self.callback(null, setup);
-      }, 3000);
     },
-    'there should be two messages': function (result) {
-      assert.equal(result.results.length, 2);
-    },
-    'messages should contain proper data': function (result) {
-      assert.equal(result.results[0].to, 'recipient@domain.com');
-      assert.equal(result.results[0].subject, 'Log event #1');
-      assert.equal(result.results[0].text.match(new RegExp('.+Log event #[1-2]$', 'gm')).length, 2);
-      assert.equal(result.results[1].to, 'recipient@domain.com');
-      assert.equal(result.results[1].subject, 'Log event #3');
-      assert.ok(new RegExp('.+Log event #3\n$').test(result.results[1].text));
-    }
-  },
-  'error when sending email': {
-    topic: function() {
-      var setup = setupLogging('error when sending email', {
-        recipients: 'recipient@domain.com',
-        sendInterval: 0,
-        SMTP: { port: 25, auth: { user: 'user@domain.com' } }
-      });
+    'error when sending email': {
+        topic: function () {
+            var setup = setupLogging('error when sending email', {
+                recipients: 'recipient@domain.com',
+                sendInterval: 0,
+                SMTP: {port: 25, auth: {user: 'user@domain.com'}}
+            });
 
-      setup.mailer.createTransport = function() {
-        return {
-          sendMail: function(msg, cb) {
-            cb({ message: "oh noes" });
-          },
-          close: function() { }
-        };
-      };
+            setup.mailer.createTransport = function () {
+                return {
+                    sendMail: function (msg, cb) {
+                        cb({message: "oh noes"});
+                    },
+                    close: function () {
+                    }
+                };
+            };
 
-      setup.logger.info("This will break");
-      return setup.console;
+            setup.logger.info("This will break");
+            return setup.console;
+        },
+        'should be logged to console': function (cons) {
+            assert.equal(cons.errors.length, 1);
+            assert.equal(cons.errors[0].msg, "log4js.smtpAppender - Error happened");
+            assert.equal(cons.errors[0].value.message, 'oh noes');
+        }
     },
-    'should be logged to console': function(cons) {
-      assert.equal(cons.errors.length, 1);
-      assert.equal(cons.errors[0].msg, "log4js.smtpAppender - Error happened");
-      assert.equal(cons.errors[0].value.message, 'oh noes');
+    'transport full config': {
+        topic: function () {
+            var setup = setupLogging('transport full config', {
+                recipients: 'recipient@domain.com',
+                transport: {
+                    plugin: 'sendmail',
+                    options: {
+                        path: '/usr/sbin/sendmail'
+                    }
+                }
+            });
+            setup.logger.info('Log event #1');
+            return setup;
+        },
+        'there should be one message only': function (result) {
+            assert.equal(result.results.length, 1);
+        },
+        'message should contain proper data': function (result) {
+            checkMessages(result);
+        }
+    },
+    'transport no-options config': {
+        topic: function () {
+            var setup = setupLogging('transport no-options config', {
+                recipients: 'recipient@domain.com',
+                transport: {
+                    plugin: 'sendmail'
+                }
+            });
+            setup.logger.info('Log event #1');
+            return setup;
+        },
+        'there should be one message only': function (result) {
+            assert.equal(result.results.length, 1);
+        },
+        'message should contain proper data': function (result) {
+            checkMessages(result);
+        }
+    },
+    'transport no-plugin config': {
+        topic: function () {
+            var setup = setupLogging('transport no-plugin config', {
+                recipients: 'recipient@domain.com',
+                transport: {
+                }
+            });
+            setup.logger.info('Log event #1');
+            return setup;
+        },
+        'there should be one message only': function (result) {
+            assert.equal(result.results.length, 1);
+        },
+        'message should contain proper data': function (result) {
+            checkMessages(result);
+        }
     }
-  },
-  'transport full config': {
-    topic: function() {
-      var setup = setupLogging('transport full config', {
-          recipients: 'recipient@domain.com',
-          transport: {
-              plugin: 'sendmail',
-              options: {
-                  path: '/usr/sbin/sendmail'
-              }
-          }
-      });
-      setup.logger.info('Log event #1');
-      return setup;
-    },
-    'there should be one message only': function (result) {
-      assert.equal(result.results.length, 1);
-    },
-    'message should contain proper data': function (result) {
-      checkMessages(result);
-    }
-  },
-  'transport no-options config': {
-    topic: function() {
-      var setup = setupLogging('transport no-options config', {
-          recipients: 'recipient@domain.com',
-          transport: {
-              plugin: 'sendmail'
-          }
-      });
-      setup.logger.info('Log event #1');
-      return setup;
-    },
-    'there should be one message only': function (result) {
-      assert.equal(result.results.length, 1);
-    },
-    'message should contain proper data': function (result) {
-      checkMessages(result);
-    }
-  },
-  'transport no-plugin config': {
-    topic: function() {
-      var setup = setupLogging('transport no-plugin config', {
-          recipients: 'recipient@domain.com',
-          transport: {
-          }
-      });
-      setup.logger.info('Log event #1');
-      return setup;
-    },
-    'there should be one message only': function (result) {
-      assert.equal(result.results.length, 1);
-    },
-    'message should contain proper data': function (result) {
-      checkMessages(result);
-    }
-  }
 }).export(module);


### PR DESCRIPTION
Please find attached a patch for log4js SMTP appender that allows to send an email with remaining logs when shutdown method is called. This is useful when we want a one-shot email when a program ending and don't wait the timeout.

Other small changes (out of appender scope) :
- Show process details when vows is launched;
- Ignore other generated temporary files with pattern test/streams/test-*