### PR TITLE
fix shutdown callbacks not being called

### DIFF
--- a/lib/appenders/dateFile.js
+++ b/lib/appenders/dateFile.js
@@ -65,6 +65,9 @@ function shutdown(cb) {
       cb(error);
     }
   };
+  if (!openFiles.length) {
+    return cb();
+  }
   openFiles.forEach(function(file) {
     if (!file.write(eol, "utf-8")) {
       file.once('drain', function() {

--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -93,6 +93,9 @@ function shutdown(cb) {
       cb(error);
     }
   };
+  if (!openFiles.length) {
+    return cb();
+  }
   openFiles.forEach(function(file) {
     if (!file.write(eol, "utf-8")) {
       file.once('drain', function() {

--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -444,6 +444,9 @@ function shutdown(cb) {
       shutdownFcts.push(appenderShutdowns[category]);
     }
   }
+  if (!shutdownFcts.length) {
+    return cb();
+  }
   shutdownFcts.forEach(function(shutdownFct) { shutdownFct(complete); });
 }
 


### PR DESCRIPTION
Bug in https://github.com/nomiddlename/log4js-node/pull/345, `N.shutdown` currently never calls its callback in a few cases:

1. When no appenders with shutdown functions are loaded (for example, we're in a worker with only `clustered` appender loaded), the amount of shutdown functions is zero. So callback is never called 'cause it waits for a finish of at least one shutdown function.
2. When file appender is loaded, but not actually used, an amount of open files is zero. Same thing, callback is never called.

Same for dateFile apparently, although I didn't test that.

// cc: @hmalphettes