### PR TITLE
Feature/MailGunAppender

### DIFF
--- a/lib/appenders/mailgun.js
+++ b/lib/appenders/mailgun.js
@@ -1,0 +1,43 @@
+"use strict";
+var layouts = require('../layouts');
+var layout;
+var config;
+var mailgun = require('mailgun-js');
+
+
+function mailgunAppender(_config, _layout) {
+
+    config = _config;
+    layout = _layout || layouts.basicLayout;
+
+    return function (loggingEvent) {
+
+        var data = {
+            from: _config.from,
+            to: _config.to,
+            subject: _config.subject,
+            text: layout(loggingEvent, config.timezoneOffset)
+        }
+
+        mailgun.messages().send(data, function (error, body) {
+            if (error != null) console.error('log4js.mailgunAppender - Error happened', error);
+        });
+    };
+}
+
+function configure(_config) {
+    config = _config;
+
+    if (_config.layout) {
+        layout = layouts.layout(_config.layout.type, _config.layout);
+    }
+
+    mailgun.apiKey = config.apikey;
+    mailgun.domain = config.domain;
+
+    return mailgunAppender(_config, layout);
+}
+
+exports.appender = mailgunAppender;
+exports.configure = configure;
+

--- a/lib/appenders/mailgun.js
+++ b/lib/appenders/mailgun.js
@@ -17,7 +17,7 @@ function mailgunAppender(_config, _layout) {
             to: _config.to,
             subject: _config.subject,
             text: layout(loggingEvent, config.timezoneOffset)
-        }
+        };
 
         mailgun.messages().send(data, function (error, body) {
             if (error != null) console.error('log4js.mailgunAppender - Error happened', error);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lib": "lib"
   },
   "dependencies": {
+    "mailgun-js": "^0.7.7",
     "readable-stream": "~1.0.2",
     "semver": "~4.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "lib": "lib"
   },
   "dependencies": {
-    "mailgun-js": "^0.7.7",
     "readable-stream": "~1.0.2",
     "semver": "~4.3.3"
   },

--- a/test/mailgunAppender-test.js
+++ b/test/mailgunAppender-test.js
@@ -1,0 +1,190 @@
+"use strict";
+var vows = require('vows');
+var assert = require('assert');
+var log4js = require('../lib/log4js');
+var sandbox = require('sandboxed-module');
+
+function setupLogging(category, options) {
+    var msgs = [];
+
+    var mailgunCredentials = {
+        apiKey: options.apikey,
+        domain: options.domain
+    }
+
+    var fakeMailgun = {
+        messages: function () {
+            return {
+                config: options,
+                send: function (data, callback) {
+                    msgs.push(data);
+                    callback(false, {status:"OK"});
+                }
+            };
+        }
+    };
+
+    var fakeLayouts = {
+        layout: function (type, config) {
+            this.type = type;
+            this.config = config;
+            return log4js.layouts.messagePassThroughLayout;
+        },
+        basicLayout: log4js.layouts.basicLayout,
+        messagePassThroughLayout: log4js.layouts.messagePassThroughLayout
+    };
+
+    var fakeConsole = {
+        errors: [],
+        logs: [],
+        error: function (msg, value) {
+            this.errors.push({msg: msg, value: value});
+        },
+        log: function (msg, value) {
+            this.logs.push({msg: msg, value: value});
+        }
+    };
+
+
+    var mailgunModule = sandbox.require('../lib/appenders/mailgun', {
+        requires: {
+            'mailgun-js': fakeMailgun,
+            '../layouts': fakeLayouts
+        },
+        globals: {
+            console: fakeConsole
+        }
+    });
+
+
+    log4js.addAppender(mailgunModule.configure(options), category);
+
+    return {
+        logger: log4js.getLogger(category),
+        mailer: fakeMailgun,
+        layouts: fakeLayouts,
+        console: fakeConsole,
+        mails: msgs,
+        credentials: mailgunCredentials
+    };
+}
+
+function checkMessages(result) {
+    for (var i = 0; i < result.mails.length; ++i) {
+        assert.equal(result.mails[i].from, 'sender@domain.com');
+        assert.equal(result.mails[i].to, 'recepient@domain.com');
+        assert.equal(result.mails[i].subject, 'This is subject');
+        assert.ok(new RegExp('.+Log event #' + (i + 1)).test(result.mails[i].text));
+    }
+}
+
+log4js.clearAppenders();
+
+vows.describe('log4js mailgunAppender').addBatch({
+    'mailgun setup': {
+        topic: setupLogging('mailgun setup', {
+                apikey: 'APIKEY',
+                domain: 'DOMAIN',
+                from: 'sender@domain.com',
+                to: 'recepient@domain.com',
+                subject: 'This is subject'
+        }),
+        'mailgun credentials should match': function(result){
+            assert.equal(result.credentials.apiKey, 'APIKEY');
+            assert.equal(result.credentials.domain, 'DOMAIN');
+        }
+    },
+
+    'basic usage': {
+        topic: function(){
+            var setup = setupLogging('basic usage', {
+                apikey: 'APIKEY',
+                domain: 'DOMAIN',
+                from: 'sender@domain.com',
+                to: 'recepient@domain.com',
+                subject: 'This is subject'
+            });
+
+            setup.logger.info("Log event #1");
+            return setup;
+        },
+        'there should be one message only': function (result) {
+            assert.equal(result.mails.length, 1);
+        },
+        'message should contain proper data': function (result) {
+            checkMessages(result);
+        }
+    },
+    'config with layout': {
+        topic: function () {
+            var setup = setupLogging('config with layout', {
+                layout: {
+                    type: "tester"
+                }
+            });
+            return setup;
+        },
+        'should configure layout': function (result) {
+            assert.equal(result.layouts.type, 'tester');
+        }
+    },
+    'error when sending email': {
+        topic: function () {
+            var setup = setupLogging('separate email for each event', {
+                apikey: 'APIKEY',
+                domain: 'DOMAIN',
+                from: 'sender@domain.com',
+                to: 'recepient@domain.com',
+                subject: 'This is subject'
+            });
+
+            setup.mailer.messages = function () {
+                    return {
+                        send: function (msg, cb) {
+                            cb({message: "oh noes"});
+                        }
+                    };
+            }
+
+            setup.logger.info("This will break");
+            return setup.console;
+        },
+        'should be logged to console': function (cons) {
+            assert.equal(cons.errors.length, 1);
+            assert.equal(cons.errors[0].msg, 'log4js.mailgunAppender - Error happened');
+            assert.equal(cons.errors[0].value.message, 'oh noes');
+        }
+    },
+    'separate email for each event': {
+        topic: function () {
+            var self = this;
+            var setup = setupLogging('separate email for each event', {
+                apikey: 'APIKEY',
+                domain: 'DOMAIN',
+                from: 'sender@domain.com',
+                to: 'recepient@domain.com',
+                subject: 'This is subject'
+            });
+            setTimeout(function () {
+                setup.logger.info('Log event #1');
+            }, 0);
+            setTimeout(function () {
+                setup.logger.info('Log event #2');
+            }, 500);
+            setTimeout(function () {
+                setup.logger.info('Log event #3');
+            }, 1100);
+            setTimeout(function () {
+                self.callback(null, setup);
+            }, 3000);
+        },
+        'there should be three messages': function (result) {
+            assert.equal(result.mails.length, 3);
+        },
+        'messages should contain proper data': function (result) {
+            checkMessages(result);
+        }
+    }
+
+}).export(module);
+


### PR DESCRIPTION
## Mailgun Appender
Created an appender for using against mailgun API
The usage is very simple just add as any other appender. 
Im adding a simple usage example:

`appender: {
                  type: 'mailgun',
                  apikey: 'MAILGUN_API_KEY',
                  domain: 'MAILGUN_SENDING_DOMAIN',
                  from: 'sender@domain.com',
                  to: 'recepient@domain.com',
                  subject: 'Some Subject'
              }`

by the moment only supports one recipient at a time.
Im planning to extend that as soon as i have some time to spare.