### PR TITLE
feat(console.js): use native console.error for ERROR level logs and higher

### DIFF
--- a/lib/appenders/console.js
+++ b/lib/appenders/console.js
@@ -1,11 +1,17 @@
 "use strict";
 var layouts = require('../layouts')
-, consoleLog = console.log.bind(console);
+, levels = require('../levels')
+, consoleLog = console.log.bind(console)
+, consoleError = console.error.bind(console);
 
 function consoleAppender (layout, timezoneOffset) {
   layout = layout || layouts.colouredLayout;
   return function(loggingEvent) {
-    consoleLog(layout(loggingEvent, timezoneOffset));
+    if (loggingEvent.level.level >= levels.ERROR.level) {
+      consoleError(layout(loggingEvent, timezoneOffset));
+    } else {
+      consoleLog(layout(loggingEvent, timezoneOffset));
+    }
   };
 }
 


### PR DESCRIPTION
Only using `console.log` and color to distinguish levels isn't appropriate, especially when using with 'pm2'. The error logs will be writted in normal 'out' logs. 
