### PR TITLE
add a stderr appender

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ framework to work with [node](http://nodejs.org). I've mainly stripped out the b
 
 Out of the box it supports the following features:
 
-* coloured console logging
+* coloured console logging to stdout or stderr
 * replacement of node's console.log functions (optional)
 * file appender, with log rolling based on file size
 * SMTP appender

--- a/lib/appenders/stderr.js
+++ b/lib/appenders/stderr.js
@@ -1,0 +1,21 @@
+"use strict";
+
+var layouts = require('../layouts')
+
+function stderrAppender(layout, timezoneOffset) {
+  layout = layout || layouts.colouredLayout;
+  return function(loggingEvent) {
+    process.stderr.write(layout(loggingEvent, timezoneOffset) + '\n');
+  };
+}
+
+function configure(config) {
+  var layout;
+  if (config.layout) {
+    layout = layouts.layout(config.layout.type, config.layout);
+  }
+  return stderrAppender(layout, config.timezoneOffset);
+}
+
+exports.appender = stderrAppender;
+exports.configure = configure;

--- a/test/stderrAppender-test.js
+++ b/test/stderrAppender-test.js
@@ -1,0 +1,35 @@
+"use strict";
+var assert = require('assert')
+, vows = require('vows')
+, layouts = require('../lib/layouts')
+, sandbox = require('sandboxed-module');
+
+vows.describe('../lib/appenders/stderr').addBatch({
+  'appender': {
+    topic: function() {
+      var messages = []
+      , fakeProcess = {
+          stderr: {
+            write: function(msg) { messages.push(msg); }
+          }
+      }
+      , appenderModule = sandbox.require(
+        '../lib/appenders/stderr',
+        {
+          globals: {
+            'process': fakeProcess
+          }
+        }
+      )
+      , appender = appenderModule.appender(layouts.messagePassThroughLayout);
+
+      appender({ data: ["blah"] });
+      return messages;
+    },
+
+    'should output to stderr': function(messages) {
+      assert.equal(messages[0], 'blah\n');
+    }
+  }
+
+}).exportTo(module);


### PR DESCRIPTION
Thus functions almost identically to the consoleAppender except that
instead of logging through `console.log` it uses `process.stderr.write`.

This is useful in cases where applications include their own console
output to stdout but want to have debug / error logs that go to stderr
so users can potentially redirect to separate out the logs from the output.
