### PR TITLE
Feature/use more appropriate console api functions

### DIFF
--- a/lib/appenders/console.js
+++ b/lib/appenders/console.js
@@ -1,9 +1,9 @@
 "use strict";
 var layouts = require('../layouts')
-  , consoleLog = console.log.bind(console)
-  , consoleDebug = console.debug && console.debug.bind(console) || consoleLog
-  , consoleWarn = console.warn.bind(console)
-  , consoleError = console.error.bind(console)
+  , consoleLog = console.log.bind && console.log.bind(console) || console.log
+  , consoleDebug = console.debug && console.debug.bind && console.debug.bind(console) || console.debug || consoleLog
+  , consoleWarn = console.warn && console.warn.bind && console.warn.bind(console) || console.warn || consoleLog
+  , consoleError = console.error.bind && console.error.bind(console) || console.error
   , levelToConsoleFnMap = {
     TRACE: consoleLog,
     DEBUG: consoleDebug,

--- a/lib/appenders/console.js
+++ b/lib/appenders/console.js
@@ -1,11 +1,23 @@
 "use strict";
 var layouts = require('../layouts')
-, consoleLog = console.log.bind(console);
+  , consoleLog = console.log.bind(console)
+  , consoleDebug = console.debug && console.debug.bind(console) || consoleLog
+  , consoleWarn = console.warn.bind(console)
+  , consoleError = console.error.bind(console)
+  , levelToConsoleFnMap = {
+    TRACE: consoleLog,
+    DEBUG: consoleDebug,
+    INFO: consoleLog,
+    WARN: consoleWarn,
+    ERROR: consoleError,
+    FATAL: consoleError
+};
 
 function consoleAppender (layout, timezoneOffset) {
   layout = layout || layouts.colouredLayout;
   return function(loggingEvent) {
-    consoleLog(layout(loggingEvent, timezoneOffset));
+    var consoleLoggerFn = levelToConsoleFnMap[loggingEvent.level.levelStr] || consoleWarn;
+    consoleLoggerFn(layout(loggingEvent, timezoneOffset));
   };
 }
 


### PR DESCRIPTION
Proposing a way to use more appropriate console "log" functions so that we take advantage of the node or browser native console implementation.

i.e. 

- logger.debug will appear in blue in a browser
- logger.error will appear in red
- logger.warn will appear in orange in a browser,