### PR TITLE
Feature/loggly shutdown

### DIFF
--- a/lib/appenders/loggly.js
+++ b/lib/appenders/loggly.js
@@ -2,8 +2,9 @@
 var layouts = require('../layouts')
 , loggly = require('loggly')
 , os = require('os')
-, passThrough = layouts.messagePassThroughLayout;
-
+, passThrough = layouts.messagePassThroughLayout
+, openRequests = 0
+, shutdownCB;
 
 function isAnyObject(value) {
 	return value != null && (typeof value === 'object' || typeof value === 'function');
@@ -50,7 +51,7 @@ function processTags(msgListArgs) {
  * {
  *   token: 'your-really-long-input-token',
  *   subdomain: 'your-subdomain',
- *   tags: ['loggly-tag1', 'loggly-tag2', .., 'loggly-tagn'] 
+ *   tags: ['loggly-tag1', 'loggly-tag2', .., 'loggly-tagn']
  * }
  * @param layout a function that takes a logevent and returns a string (defaults to objectLayout).
  */
@@ -68,13 +69,27 @@ function logglyAppender(config, layout) {
 
     var msg = layout(loggingEvent);
 
+		openRequests++;
+
 		client.log({
 			msg: msg,
 			level: loggingEvent.level.levelStr,
 			category: loggingEvent.categoryName,
 			hostname: os.hostname().toString(),
-		}, additionalTags);
-  }
+		}, additionalTags, function (error, result) {
+			if (error) {
+				console.error("log4js.logglyAppender - Logging to loggly, error happende ", error);
+			}
+
+			openRequests--;
+
+			if (shutdownCB && openRequests === 0) {
+				shutdownCB();
+
+				shutdownCB = undefined;
+			}
+		});
+  };
 }
 
 function configure(config) {
@@ -85,6 +100,15 @@ function configure(config) {
 	return logglyAppender(config, layout);
 }
 
+function shutdown (cb) {
+	if (openRequests === 0) {
+		cb();
+	}	else {
+		shutdownCB = cb;
+	}
+}
+
 exports.name      = 'loggly';
 exports.appender  = logglyAppender;
 exports.configure = configure;
+exports.shutdown  = shutdown;

--- a/test/logglyAppender-test.js
+++ b/test/logglyAppender-test.js
@@ -12,10 +12,11 @@ function setupLogging(category, options) {
     createClient: function(options) {
       return {
         config: options,
-        log: function(msg, tags) {
+        log: function(msg, tags, cb) {
           msgs.push({
             msg: msg,
-            tags: tags
+            tags: tags,
+            cb: cb
           });
         }
       };
@@ -105,6 +106,33 @@ vows.describe('log4js logglyAppender').addBatch({
     },
     'has a result tags with the arg that contains no tags': function(topic) {
       assert.deepEqual(topic.results[0].tags, []);
+    }
+  }
+}).addBatch({
+  'with shutdown callback': {
+    topic: function() {
+      var setup = setupTaggedLogging();
+
+      setup.logger.log('trace', 'Log event #1', 'Log 2', {
+        tags: ['tag1', 'tag2']
+      });
+
+      return setup;
+    },
+    'after the last message has been sent': {
+      topic: function (topic) {
+        var that = this;
+
+        log4js.shutdown(this.callback);
+        topic.results[0].cb();
+
+        setTimeout(function() {
+          that.callback(new Error('Shutdown callback has not been called'));
+        }, 0);
+      },
+      'calls `log4js.shutdown`s callback function.': function(error, result) {
+        assert.equal(error, undefined);
+      }
     }
   }
 }).export(module);


### PR DESCRIPTION
Follow up to #122.

I’d like to add a test for this, but it seems that appenders that are registered with `addAppender` cannot register a shutdown handler. Is this on purpose, or has this simply be forgotten when adding the shutdown handlers?

I’d be happy about any hints. Thanks.

P.S.: I also tried to adhere to the .jshintrc, though lots of files in this repo don’t. Is this file up to date? And could we add jshint as a dev dep and make it a pretest or posttest script?
