### PR TITLE
use HipChat apiv2 in hipchat appender

### DIFF
--- a/examples/hipchat-appender.js
+++ b/examples/hipchat-appender.js
@@ -1,6 +1,7 @@
 /**
- * !!! The hipchat-appender requires `hipchat-notifier` from npm
- *   - e.g. list as a dependency in your application's package.json
+ * !!! The hipchat-appender requires `hipchat-notifier` from npm, e.g.
+ *   - list as a dependency in your application's package.json ||
+ *   - npm install hipchat-notifier
  */
 
 var log4js = require('../lib/log4js');
@@ -9,24 +10,46 @@ log4js.configure({
   "appenders": [
     {
       "type" : "hipchat",
-      "hipchat_token": "< User token with Notification Privileges >",
-      "hipchat_room": "< Room ID or Name >",
-      // optional
-      "hipchat_from": "[ additional from label ]",
-      "hipchat_notify": "[ notify boolean to bug people ]",
-      "hipchat_response_callback": function(err, response, body){
-        console.log("overridden log4js hipchat-appender response callback");
-      }
+      "hipchat_token": process.env.HIPCHAT_TOKEN || '< User token with Notification Privileges >',
+      "hipchat_room": process.env.HIPCHAT_ROOM || '< Room ID or Name >'
     }
   ]
 });
 
 var logger = log4js.getLogger("hipchat");
-logger.warn("Test Warn message");//yello
-logger.info("Test Info message");//green
-logger.debug("Test Debug Message");//hipchat client has limited color scheme
-logger.trace("Test Trace Message");//so debug and trace are the same color: purple
-logger.fatal("Test Fatal Message");//hipchat client has limited color scheme
-logger.error("Test Error Message");// fatal and error are same color: red
-logger.all("Test All message");//grey
-//logger.debug("Test log message");
+logger.warn("Test Warn message");
+logger.info("Test Info message");
+logger.debug("Test Debug Message");
+logger.trace("Test Trace Message");
+logger.fatal("Test Fatal Message");
+logger.error("Test Error Message");
+
+// alternative configuration
+
+// use a custom layout function
+//   format: [TIMESTAMP][LEVEL][category] - [message]
+var customLayout = require('../lib/layouts').basicLayout;
+
+log4js.configure({
+  "appenders": [
+    {
+      "type" : "hipchat",
+      "hipchat_token": process.env.HIPCHAT_TOKEN || '< User token with Notification Privileges >',
+      "hipchat_room": process.env.HIPCHAT_ROOM || '< Room ID or Name >',
+      "hipchat_from": "Mr. Semantics",
+      "hipchat_notify": false,
+      "hipchat_response_callback": function(err, response, body){
+        if(err || response.statusCode > 300){
+          throw new Error('hipchat-notifier failed');
+        }
+        console.log('mr semantics callback success');
+      },
+      "layout": customLayout
+    }
+  ]
+});
+
+logger.info("Test from processed by customLayout");
+
+// @TODO: implement configuration of send message to allow HipChat cards &c
+//        for now, can try to implement by returning object from custom layout

--- a/examples/hipchat-appender.js
+++ b/examples/hipchat-appender.js
@@ -24,9 +24,11 @@ logger.trace("Test Trace Message");
 logger.fatal("Test Fatal Message");
 logger.error("Test Error Message");
 
-// alternative configuration
 
-// use a custom layout function
+// alternative configuration demonstrating callback + custom layout
+///////////////////////////////////////////////////////////////////
+
+// use a custom layout function (in this case, the provided basicLayout)
 //   format: [TIMESTAMP][LEVEL][category] - [message]
 var customLayout = require('../lib/layouts').basicLayout;
 
@@ -49,7 +51,4 @@ log4js.configure({
   ]
 });
 
-logger.info("Test from processed by customLayout");
-
-// @TODO: implement configuration of send message to allow HipChat cards &c
-//        for now, can try to implement by returning object from custom layout
+logger.info("Test customLayout from Mr. Semantics");

--- a/examples/hipchat-appender.js
+++ b/examples/hipchat-appender.js
@@ -1,18 +1,20 @@
-//Note that hipchat appender needs hipchat-client to work.
-//If you haven't got hipchat-client installed, you'll get cryptic
-//"cannot find module" errors when using the hipchat appender
+
+/**
+ * !!! The hipchat-appender requires `hipchat-notifier` from npm
+ *   - e.g. list as a dependency in your application's package.json
+ */
+
 var log4js = require('../lib/log4js');
 
 log4js.configure({
   "appenders": [
     {
       "type" : "hipchat",
-      "api_key": 'Hipchat_API_V1_Key',
-      "room_id": "Room_ID",
-      "from": "Tester",
-      "format": "text",
-      "notify": "NOTIFY",
-      "category" : "hipchat"
+      "hipchat_token": "< User token with Notification Privileges >",
+      "hipchat_room": "< Room ID or Name >",
+      // optionl
+      "hipchat_from": "[ additional from label ]",
+      "hipchat_notify": "[ notify boolean to bug people ]"
     }
   ]
 });

--- a/examples/hipchat-appender.js
+++ b/examples/hipchat-appender.js
@@ -1,4 +1,3 @@
-
 /**
  * !!! The hipchat-appender requires `hipchat-notifier` from npm
  *   - e.g. list as a dependency in your application's package.json
@@ -12,9 +11,12 @@ log4js.configure({
       "type" : "hipchat",
       "hipchat_token": "< User token with Notification Privileges >",
       "hipchat_room": "< Room ID or Name >",
-      // optionl
+      // optional
       "hipchat_from": "[ additional from label ]",
-      "hipchat_notify": "[ notify boolean to bug people ]"
+      "hipchat_notify": "[ notify boolean to bug people ]",
+      "hipchat_response_callback": function(err, response, body){
+        console.log("overridden log4js hipchat-appender response callback");
+      }
     }
   ]
 });

--- a/lib/appenders/hipchat.js
+++ b/lib/appenders/hipchat.js
@@ -1,4 +1,5 @@
 "use strict";
+
 var hipchat = require('hipchat-notifier');
 var layouts = require('../layouts');
 
@@ -44,6 +45,8 @@ function hipchatAppender(config, layout) {
   // @lint W074 This function's cyclomatic complexity is too high. (10)
   return function(loggingEvent){
 
+    var notifierFn;
+
     notifier.setRoom(config.hipchat_room);
     notifier.setRoom(config.hipchat_room);
     notifier.setFrom(config.hipchat_from || '');
@@ -53,11 +56,10 @@ function hipchatAppender(config, layout) {
       notifier.setHost(config.hipchat_host);
     }
 
-    var notifierFn = "success";
     switch (loggingEvent.level.toString()) {
       case "TRACE":
       case "DEBUG":
-        notifierFn = "notice";
+        notifierFn = "info";
         break;
       case "WARN":
         notifierFn = "warning";
@@ -67,7 +69,7 @@ function hipchatAppender(config, layout) {
         notifierFn = "failure";
         break;
       default:
-        notifierFn = "info";
+        notifierFn = "success";
     }
 
     // @TODO, re-work in timezoneOffset ?

--- a/lib/appenders/hipchat.js
+++ b/lib/appenders/hipchat.js
@@ -7,48 +7,50 @@ var hipchat, config;
 
 //hipchat has more limited colors
 var colours = {
-    ALL: "grey",
-    TRACE: "purple",
-    DEBUG: "purple",
-    INFO: "green",
-    WARN: "yellow",
-    ERROR: "red",
-    FATAL: "red",
-    OFF: "grey"
+  ALL: "grey",
+  TRACE: "purple",
+  DEBUG: "purple",
+  INFO: "green",
+  WARN: "yellow",
+  ERROR: "red",
+  FATAL: "red",
+  OFF: "grey"
 };
 
 function hipchatAppender(_config, _layout) {
 
-    layout = _layout || layouts.basicLayout;
+  layout = _layout || layouts.basicLayout;
 
-    return function (loggingEvent) {
+  return function(loggingEvent) {
 
-        var data = {
-            room_id: _config.room_id,
-            from: _config.from,
-            message: layout(loggingEvent, _config.timezoneOffset),
-            format: _config.format,
-            color: colours[loggingEvent.level.toString()],
-            notify: _config.notify
-        };
-
-        hipchat.api.rooms.message(data, function (err, res) {
-            if (err) { throw err; }
-        });
+    var data = {
+      room_id: _config.room_id,
+      from: _config.from,
+      message: layout(loggingEvent, _config.timezoneOffset),
+      format: _config.format,
+      color: colours[loggingEvent.level.toString()],
+      notify: _config.notify
     };
+
+    hipchat.api.rooms.message(data, function(err, res) {
+      if (err) {
+        throw err;
+      }
+    });
+  };
 }
 
 function configure(_config) {
 
-    if (_config.layout) {
-        layout = layouts.layout(_config.layout.type, _config.layout);
-    }
+  if (_config.layout) {
+    layout = layouts.layout(_config.layout.type, _config.layout);
+  }
 
-    hipchat = new HipChatClient(_config.api_key);
+  hipchat = new HipChatClient(_config.api_key);
 
-    return hipchatAppender(_config, layout);
+  return hipchatAppender(_config, layout);
 }
 
-exports.name      = 'hipchat';
+exports.name = 'hipchat';
 exports.appender = hipchatAppender;
 exports.configure = configure;

--- a/lib/appenders/hipchat.js
+++ b/lib/appenders/hipchat.js
@@ -8,7 +8,7 @@ exports.configure = hipchatConfigure;
 
 /**
   @invoke as
-  
+
   log4js.configure({
     "appenders": [
       {
@@ -41,7 +41,8 @@ function hipchatAppender(config, layout) {
 
   layout = layout || layouts.messagePassThroughLayout;
 
-  return function(loggingEvent) {
+  // @lint W074 This function's cyclomatic complexity is too high. (10)
+  return function(loggingEvent){
 
     notifier.setRoom(config.hipchat_room);
     notifier.setRoom(config.hipchat_room);
@@ -74,8 +75,9 @@ function hipchatAppender(config, layout) {
 
     // dispatch hipchat api request, do not return anything
     //  [overide hipchatNotifierResponseCallback]
-    notifier[notifierFn](layoutMessage, hipchatNotifierResponseCallback);
-  }
+    notifier[notifierFn](layoutMessage, config.hipchat_response_callback ||
+      hipchatNotifierResponseCallback);
+  };
 }
 
 function hipchatConfigure(config) {

--- a/lib/appenders/hipchat.js
+++ b/lib/appenders/hipchat.js
@@ -1,22 +1,34 @@
 "use strict";
-var HipChatClient = require('hipchat-client');
+var hipchat = require('hipchat-notifier');
 var layouts = require('../layouts');
 
 exports.name = 'hipchat';
 exports.appender  = hipchatAppender;
 exports.configure = hipchatConfigure;
 
-//hipchat has more limited colors
-var colours = {
-  ALL: "grey",
-  TRACE: "purple",
-  DEBUG: "purple",
-  INFO: "green",
-  WARN: "yellow",
-  ERROR: "red",
-  FATAL: "red",
-  OFF: "grey"
-};
+/**
+  @invoke as
+  log4js.configure({
+    "appenders": [
+      {
+        "type" : "hipchat",
+        "hipchat_token": "< User token with Notification Privileges >",
+        "hipchat_room": "< Room ID or Name >",
+        // optionl
+        "hipchat_from": "[ additional from label ]",
+        "hipchat_notify": "[ notify boolean to bug people ]",
+        "hipchat_host" : "api.hipchat.com"
+      }
+    ]
+  });
+  @invoke
+ */
+
+function hipchatNotifierResponseCallback(err, response, body){
+  if(err) {
+    throw err;
+  }
+}
 
 function hipchatAppender(config, layout) {
 
@@ -26,20 +38,38 @@ function hipchatAppender(config, layout) {
 
   return function(loggingEvent) {
 
-    var data = {
-      room_id: _config.room_id,
-      from: _config.from,
-      message: layout(loggingEvent, _config.timezoneOffset),
-      format: _config.format,
-      color: colours[loggingEvent.level.toString()],
-      notify: _config.notify
-    };
+    notifier.setRoom(config.hipchat_room);
+    notifier.setRoom(config.hipchat_room);
+    notifier.setFrom(config.hipchat_from || '');
+    notifier.setNotify(config.hipchat_notify || false);
 
-    client.api.rooms.message(data, function(err, res) {
-      if (err) {
-        throw err;
-      }
-    });
+    if(config.hipchat_host) {
+      notifier.setHost(config.hipchat_host);
+    }
+
+    var notifierFn = "success";
+    switch (loggingEvent.level.toString()) {
+      case "TRACE":
+      case "DEBUG":
+        notifierFn = "notice";
+        break;
+      case "WARN":
+        notifierFn = "warning";
+        break;
+      case "ERROR":
+      case "FATAL":
+        notifierFn = "failure";
+        break;
+      default:
+        notifierFn = "info";
+    }
+
+    // @TODO, re-work in timezoneOffset ?
+    var layoutMessage = layout(loggingEvent);
+
+    // dispatch hipchat api request, do not return anything
+    //  [overide hipchatNotifierResponseCallback]
+    notifier[notifierFn](layoutMessage, hipchatNotifierResponseCallback);
   }
 }
 

--- a/lib/appenders/hipchat.js
+++ b/lib/appenders/hipchat.js
@@ -46,7 +46,6 @@ function hipchatAppender(config) {
     var notifierFn;
 
     notifier.setRoom(config.hipchat_room);
-    notifier.setRoom(config.hipchat_room);
     notifier.setFrom(config.hipchat_from || '');
     notifier.setNotify(config.hipchat_notify || false);
 

--- a/lib/appenders/hipchat.js
+++ b/lib/appenders/hipchat.js
@@ -8,6 +8,7 @@ exports.configure = hipchatConfigure;
 
 /**
   @invoke as
+  
   log4js.configure({
     "appenders": [
       {
@@ -21,6 +22,10 @@ exports.configure = hipchatConfigure;
       }
     ]
   });
+
+  var logger = log4js.getLogger("hipchat");
+  logger.warn("Test Warn message");
+
   @invoke
  */
 

--- a/lib/appenders/hipchat.js
+++ b/lib/appenders/hipchat.js
@@ -1,9 +1,10 @@
 "use strict";
 var HipChatClient = require('hipchat-client');
 var layouts = require('../layouts');
-var layout;
 
-var hipchat, config;
+exports.name = 'hipchat';
+exports.appender  = hipchatAppender;
+exports.configure = hipchatConfigure;
 
 //hipchat has more limited colors
 var colours = {
@@ -17,9 +18,10 @@ var colours = {
   OFF: "grey"
 };
 
-function hipchatAppender(_config, _layout) {
+function hipchatAppender(config, layout) {
 
-  layout = _layout || layouts.basicLayout;
+	var client = new HipChatClient(_config.api_key);
+  layout = layout || layouts.basicLayout;
 
   return function(loggingEvent) {
 
@@ -32,25 +34,18 @@ function hipchatAppender(_config, _layout) {
       notify: _config.notify
     };
 
-    hipchat.api.rooms.message(data, function(err, res) {
+    client.api.rooms.message(data, function(err, res) {
       if (err) {
         throw err;
       }
     });
-  };
-}
-
-function configure(_config) {
-
-  if (_config.layout) {
-    layout = layouts.layout(_config.layout.type, _config.layout);
   }
-
-  hipchat = new HipChatClient(_config.api_key);
-
-  return hipchatAppender(_config, layout);
 }
 
-exports.name = 'hipchat';
-exports.appender = hipchatAppender;
-exports.configure = configure;
+function hipchatConfigure(config) {
+	var layout;
+	if (config.layout) {
+		layout = layouts.layout(config.layout.type, config.layout);
+	}
+	return hipchatAppender(config, layout);
+}

--- a/lib/appenders/hipchat.js
+++ b/lib/appenders/hipchat.js
@@ -36,11 +36,9 @@ function hipchatNotifierResponseCallback(err, response, body){
   }
 }
 
-function hipchatAppender(config, layout) {
+function hipchatAppender(config) {
 
 	var notifier = hipchat.make(config.hipchat_room, config.hipchat_token);
-
-  layout = layout || layouts.messagePassThroughLayout;
 
   // @lint W074 This function's cyclomatic complexity is too high. (10)
   return function(loggingEvent){
@@ -73,7 +71,7 @@ function hipchatAppender(config, layout) {
     }
 
     // @TODO, re-work in timezoneOffset ?
-    var layoutMessage = layout(loggingEvent);
+    var layoutMessage = config.layout(loggingEvent);
 
     // dispatch hipchat api request, do not return anything
     //  [overide hipchatNotifierResponseCallback]
@@ -84,8 +82,13 @@ function hipchatAppender(config, layout) {
 
 function hipchatConfigure(config) {
 	var layout;
-	if (config.layout) {
-		layout = layouts.layout(config.layout.type, config.layout);
+
+	if (!config.layout) {
+		config.layout = layouts.messagePassThroughLayout;
 	}
+
+  // @TODO: implement configuration of send message to allow HipChat cards &c
+  //        for now, can try to implement by returning object from custom layout
+
 	return hipchatAppender(config, layout);
 }

--- a/lib/appenders/hipchat.js
+++ b/lib/appenders/hipchat.js
@@ -86,8 +86,5 @@ function hipchatConfigure(config) {
 		config.layout = layouts.messagePassThroughLayout;
 	}
 
-  // @TODO: implement configuration of send message to allow HipChat cards &c
-  //        for now, can try to implement by returning object from custom layout
-
 	return hipchatAppender(config, layout);
 }

--- a/lib/appenders/hipchat.js
+++ b/lib/appenders/hipchat.js
@@ -20,8 +20,9 @@ var colours = {
 
 function hipchatAppender(config, layout) {
 
-	var client = new HipChatClient(_config.api_key);
-  layout = layout || layouts.basicLayout;
+	var notifier = hipchat.make(config.hipchat_room, config.hipchat_token);
+
+  layout = layout || layouts.messagePassThroughLayout;
 
   return function(loggingEvent) {
 


### PR DESCRIPTION
v1 is _very_ deprecated. lets switch to  [hipchat-notifier](https://github.com/briceburg/hipchat-notifier) library to use apiv2 and simplify. 

+1 allows named rooms
+1 is not deprecated
+1 allows configurable layout (e.g. for sending HipChat cards)

closes https://github.com/BlueAcornInc/log4js-node/issues/2