### PR TITLE
make HTTP response body available for formatting function

### DIFF
--- a/lib/appenders/gelf.js
+++ b/lib/appenders/gelf.js
@@ -104,11 +104,16 @@ function gelfAppender (layout, host, port, hostname, facility) {
   function preparePacket(loggingEvent) {
     var msg = {};
     addCustomFields(loggingEvent, msg);
-    // the issue: some loggers (eg 'connect-logger') only could pass in the log level and either formatted string or
-    // data object returned by the formatting function. In the later case (when the data object is returned) we could
-    // be using that data object to send data we need using GELF. BUT, gelf will not accept the packets with no
-    // short_messages in them, and the only way to put MEANINGFUL data in the short message (eg HTTP <method> <url>)
-    // is to write it in the [short_message] custom field returned by the 'connect-logger'. Example of the data
+    // the issue: some loggers (eg 'connect-logger') only could pass
+    // in the log level and either formatted string or
+    // data object returned by the formatting function.
+    // In the later case (when the data object is returned) we could
+    // be using that data object to send data we need using GELF.
+    // BUT, gelf will not accept the packets with no
+    // short_messages in them, and the only way to put
+    // MEANINGFUL data in the short message (eg HTTP <method> <url>)
+    // is to write it in the [short_message] custom field returned
+    // by the 'connect-logger'. Example of the data
     // returned by custom formatting function from 'connect-logger':
     // { res: { statusCode: 304, body: '' },
     //   req:
@@ -118,7 +123,7 @@ function gelfAppender (layout, host, port, hostname, facility) {
     //       connection: 'keep-alive',
     //       accept: 'application/json',
     //       'save-data': 'on',
-    //       'user-agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36',
+    //       'user-agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64)',
     //       referer: 'http://localhost:5000/explorer/',
     //       'accept-encoding': 'gzip, deflate, sdch',
     //       'accept-language': 'en-US,en;q=0.8,ru;q=0.6',
@@ -130,8 +135,10 @@ function gelfAppender (layout, host, port, hostname, facility) {
     //   short_message: 'HTTP GET /api/call/something',
     //   GELF: true
     // }
-    // NOTE: short_message is added to the custom object to it is expected to be sent to the GELF server.
-    // And we can't use layout(loggingEvent) to create an appropriate short_message cause the `data` has already been
+    // NOTE: short_message is added to the custom object to it is
+    // expected to be sent to the GELF server.
+    // And we can't use layout(loggingEvent) to create an
+    // appropriate short_message cause the `data` has already been
     // removed from the loggingEvent by `addCustomFields` function
     if (!msg.short_message)
       msg.short_message = layout(loggingEvent);
@@ -140,6 +147,8 @@ function gelfAppender (layout, host, port, hostname, facility) {
     msg.timestamp = msg.timestamp || new Date().getTime() / 1000; // log should use millisecond
     msg.host = hostname;
     msg.level = levelMapping[loggingEvent.level || levels.DEBUG];
+    if (loggingEvent.categoryName)
+      msg._category = loggingEvent.categoryName;
     return msg;
   }
 

--- a/lib/appenders/gelf.js
+++ b/lib/appenders/gelf.js
@@ -104,7 +104,37 @@ function gelfAppender (layout, host, port, hostname, facility) {
   function preparePacket(loggingEvent) {
     var msg = {};
     addCustomFields(loggingEvent, msg);
-    msg.short_message = layout(loggingEvent);
+    // the issue: some loggers (eg 'connect-logger') only could pass in the log level and either formatted string or
+    // data object returned by the formatting function. In the later case (when the data object is returned) we could
+    // be using that data object to send data we need using GELF. BUT, gelf will not accept the packets with no
+    // short_messages in them, and the only way to put MEANINGFUL data in the short message (eg HTTP <method> <url>)
+    // is to write it in the [short_message] custom field returned by the 'connect-logger'. Example of the data
+    // returned by custom formatting function from 'connect-logger':
+    // { res: { statusCode: 304, body: '' },
+    //   req:
+    //   { url: '/api/call/something',
+    //     headers:
+    //     { host: 'localhost:5000',
+    //       connection: 'keep-alive',
+    //       accept: 'application/json',
+    //       'save-data': 'on',
+    //       'user-agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36',
+    //       referer: 'http://localhost:5000/explorer/',
+    //       'accept-encoding': 'gzip, deflate, sdch',
+    //       'accept-language': 'en-US,en;q=0.8,ru;q=0.6',
+    //       'if-none-match': 'W/"1c1-aKbQ1O4ELxIEyWtW2pYWnQ"' },
+    //     method: 'GET',
+    //     httpVersion: '1.1',
+    //     body: '{}' },
+    //   responseTime: 3562,
+    //   short_message: 'HTTP GET /api/call/something',
+    //   GELF: true
+    // }
+    // NOTE: short_message is added to the custom object to it is expected to be sent to the GELF server.
+    // And we can't use layout(loggingEvent) to create an appropriate short_message cause the `data` has already been
+    // removed from the loggingEvent by `addCustomFields` function
+    if (!msg.short_message)
+      msg.short_message = layout(loggingEvent);
 
     msg.version="1.1";
     msg.timestamp = msg.timestamp || new Date().getTime() / 1000; // log should use millisecond

--- a/lib/connect-logger.js
+++ b/lib/connect-logger.js
@@ -78,25 +78,29 @@ function getLogger(logger4js, options) {
 				}
 			};
 
-			//hook on end request to emit the log entry of the HTTP request.
-			res.on('finish', function() {
-				res.responseTime = new Date() - start;
-				//status code response level handling
-				if(res.statusCode && options.level === 'auto'){
-					level = levels.INFO;
-					if(res.statusCode >= 300) level = levels.WARN;
-					if(res.statusCode >= 400) level = levels.ERROR;
-				}
-				if (thislogger.isLevelEnabled(level)) {
+      var end = res.end;
+      //hook on end request to emit the log entry of the HTTP request.
+      res.end = function (chunk, encoding) {
+        res.responseTime = new Date() - start;
+        res.body = chunk;
+        res.end = end;
+        res.end(chunk, encoding);
+        //status code response level handling
+        if(res.statusCode && options.level === 'auto'){
+          level = levels.INFO;
+          if(res.statusCode >= 300) level = levels.WARN;
+          if(res.statusCode >= 400) level = levels.ERROR;
+        }
+        if (thislogger.isLevelEnabled(level)) {
           var combined_tokens = assemble_tokens(req, res, options.tokens || []);
-					if (typeof fmt === 'function') {
-						var line = fmt(req, res, function(str){ return format(str, combined_tokens); });
-						if (line) thislogger.log(level, line);
-					} else {
-						thislogger.log(level, format(fmt, combined_tokens));
-					}
-				}
-			});
+          if (typeof fmt === 'function') {
+            var line = fmt(req, res, function(str){ return format(str, combined_tokens); });
+            if (line) thislogger.log(level, line);
+          } else {
+            thislogger.log(level, format(fmt, combined_tokens));
+          }
+        }
+      };
 		}
 
     //ensure next gets always called

--- a/test/connect-logger-test.js
+++ b/test/connect-logger-test.js
@@ -206,6 +206,23 @@ vows.describe('log4js connect logger').addBatch({
       }
     },
 
+    'format using a function with included response body': {
+      topic: function(clm) {
+        var ml = new MockLogger();
+        var cb = this.callback;
+        ml.level = levels.INFO;
+        var cl = clm.connectLogger(ml, function(req, res, formatFn) { return res.body; });
+        request(cl, 'GET', 'http://blah', 200);
+        setTimeout(function() {
+          cb(null, ml.messages);
+        },10);
+      },
+
+      'should return response body': function(messages) {
+        assert.equal(messages[0].message, 'chunk');
+      }
+    },
+
     'format that includes request headers': {
       topic: function(clm) {
         var ml = new MockLogger();


### PR DESCRIPTION
in some cases we want to log HTTP response body,  so we include a response body (Buffer) to the res object before formatting function is called.
