### PR TITLE
add req.url so that connect works with restify

### DIFF
--- a/lib/connect-logger.js
+++ b/lib/connect-logger.js
@@ -128,7 +128,7 @@ function assemble_tokens(req, res, custom_tokens) {
   };
 
   var default_tokens = [];
-  default_tokens.push({ token: ':url', replacement: req.originalUrl });
+  default_tokens.push({ token: ':url', replacement: req.originalUrl || req.url });
   default_tokens.push({ token: ':protocol', replacement: req.protocol });
   default_tokens.push({ token: ':hostname', replacement: req.hostname });
   default_tokens.push({ token: ':method', replacement: req.method });

--- a/lib/connect-logger.js
+++ b/lib/connect-logger.js
@@ -179,7 +179,8 @@ function assemble_tokens(req, res, custom_tokens) {
 
 /**
  * Return request url path,
- * adding this function prevents the Cyclomatic Complexity for the assemble_tokens function at low, to pass the tests.
+ * adding this function prevents the Cyclomatic Complexity,
+ * for the assemble_tokens function at low, to pass the tests.
  *
  * @param  {IncomingMessage} req
  * @return {String}
@@ -187,7 +188,7 @@ function assemble_tokens(req, res, custom_tokens) {
  */
 
 function getUrl(req){
-  return req.originalUrl || req.url
+  return req.originalUrl || req.url;
 }
 /**
  * Return formatted log line.

--- a/lib/connect-logger.js
+++ b/lib/connect-logger.js
@@ -128,7 +128,7 @@ function assemble_tokens(req, res, custom_tokens) {
   };
 
   var default_tokens = [];
-  default_tokens.push({ token: ':url', replacement: req.originalUrl || req.url });
+  default_tokens.push({ token: ':url', replacement: getUrl(req) });
   default_tokens.push({ token: ':protocol', replacement: req.protocol });
   default_tokens.push({ token: ':hostname', replacement: req.hostname });
   default_tokens.push({ token: ':method', replacement: req.method });
@@ -177,6 +177,18 @@ function assemble_tokens(req, res, custom_tokens) {
   return array_unique_tokens(custom_tokens.concat(default_tokens));
 }
 
+/**
+ * Return request url path,
+ * adding this function prevents the Cyclomatic Complexity for the assemble_tokens function at low, to pass the tests.
+ *
+ * @param  {IncomingMessage} req
+ * @return {String}
+ * @api private
+ */
+
+function getUrl(req){
+  return req.originalUrl || req.url
+}
 /**
  * Return formatted log line.
  *


### PR DESCRIPTION
restify uses req.url to denote the invoked url path for http, this change allows to make the logger connect work with restify out of the box