### PR TITLE
Don't try to load an appender that's already been loaded

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -427,17 +427,19 @@ function requireAppender(appender) {
  * @private
  */
 function loadAppender(appender, appenderModule) {
-  appenderModule = appenderModule || requireAppender(appender);
+  if (!module.exports.appenders[appender]) {
+    appenderModule = appenderModule || requireAppender(appender);
 
-  if (!appenderModule) {
-    throw new Error("Invalid log4js appender: " + util.inspect(appender));
-  }
+    if (!appenderModule) {
+      throw new Error("Invalid log4js appender: " + util.inspect(appender));
+    }
 
-  module.exports.appenders[appender] = appenderModule.appender.bind(appenderModule);
-  if (appenderModule.shutdown) {
-    appenderShutdowns[appender] = appenderModule.shutdown.bind(appenderModule);
+    module.exports.appenders[appender] = appenderModule.appender.bind(appenderModule);
+    if (appenderModule.shutdown) {
+      appenderShutdowns[appender] = appenderModule.shutdown.bind(appenderModule);
+    }
+    appenderMakers[appender] = appenderModule.configure.bind(appenderModule);
   }
-  appenderMakers[appender] = appenderModule.configure.bind(appenderModule);
 }
 
 /**


### PR DESCRIPTION
We have a scenario where we want to load a local custom appender by passing a pre-required module, and then configure it with JSON, eg:

**excerpt from _logging.js_**

```
log4js = require('log4js');
log4js.loadAppender('sms', require('./smsLogger'));
log4js.configure('./logging.json');
```

**excerpt from _logging.json_**

```
{
  "appenders": [
    {
      "type": "console",
      "level": "DEBUG"
    },
    ...,
    {
      "type": "sms",
      "level": "ERROR"
    }
  ]
}
```

However, the configure method tries to reload an _sms_ appender. This clobbers the one just manually added, and promptly falls over, as it's not on the require path.

This PR adds a guard which just stops pre-existing appenders from being clobbered.
