### PR TITLE
fix for #315 - Include milliseconds in format ISO8601_WITH_TZ_OFFSET

### DIFF
--- a/lib/date_format.js
+++ b/lib/date_format.js
@@ -1,6 +1,6 @@
 "use strict";
 exports.ISO8601_FORMAT = "yyyy-MM-dd hh:mm:ss.SSS";
-exports.ISO8601_WITH_TZ_OFFSET_FORMAT = "yyyy-MM-ddThh:mm:ssO";
+exports.ISO8601_WITH_TZ_OFFSET_FORMAT = "yyyy-MM-ddThh:mm:ss.SSSO";
 exports.DATETIME_FORMAT = "dd MM yyyy hh:mm:ss.SSS";
 exports.ABSOLUTETIME_FORMAT = "hh:mm:ss.SSS";
 

--- a/test/vows/date_format-test.js
+++ b/test/vows/date_format-test.js
@@ -28,14 +28,14 @@ vows.describe('date_format').addBatch({
       date.getTimezoneOffset = function() { return -660; };
       assert.equal(
         dateFormat.asString(dateFormat.ISO8601_WITH_TZ_OFFSET_FORMAT, date),
-        "2010-01-11T14:31:30+1100"
+        "2010-01-11T14:31:30.005+1100"
       );
       date = createFixedDate();
       date.setMinutes(date.getMinutes() - date.getTimezoneOffset() + 120);
       date.getTimezoneOffset = function() { return 120; };
       assert.equal(
         dateFormat.asString(dateFormat.ISO8601_WITH_TZ_OFFSET_FORMAT, date),
-        "2010-01-11T14:31:30-0200"
+        "2010-01-11T14:31:30.005-0200"
       );
 
     },

--- a/test/vows/layouts-test.js
+++ b/test/vows/layouts-test.js
@@ -252,7 +252,7 @@ vows.describe('log4js layouts').addBatch({
       test(args, '%d', '2010-12-05 14:18:30.045');
     },
     '%d should allow for format specification': function(args) {
-      test(args, '%d{ISO8601_WITH_TZ_OFFSET}', '2010-12-05T14:18:30-0000');
+      test(args, '%d{ISO8601_WITH_TZ_OFFSET}', '2010-12-05T14:18:30.045-0000');
       test(args, '%d{ISO8601}', '2010-12-05 14:18:30.045');
       test(args, '%d{ABSOLUTE}', '14:18:30.045');
       test(args, '%d{DATE}', '05 12 2010 14:18:30.045');


### PR DESCRIPTION
Without milliseconds, the output of the log when sent to log collector, such as Logstash or Kibana, are not useful. Because Kibana uses the timestamp to sort the log, then the order of the log not always display correctly within one second.