### PR TITLE
Added support for passing a function/closure to the logger

### DIFF
--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -51,6 +51,9 @@ function formatLogData(logData) {
       data[i] = arguments[i];
     }
   }
+  
+  data = data.map(function(elem) { return (typeof elem == 'function') ? elem() : elem; });
+  
   return util.format.apply(util, wrapErrorsWithInspect(data));
 }
 

--- a/test/vows/layouts-test.js
+++ b/test/vows/layouts-test.js
@@ -59,6 +59,17 @@ vows.describe('log4js layouts').addBatch({
         }
       }), "nonsense");
     },
+    'should take a logevent and output only the evaluated message function' : function(layout) {
+      assert.equal(layout({
+                            data: [function() { return "nonsense"; }],
+                            startTime: new Date(2010, 11, 5, 14, 18, 30, 45),
+                            categoryName: "cheese",
+                            level: {
+                              colour: "green",
+                              toString: function() { return "ERROR"; }
+                            }
+                          }), "nonsense");
+    },
     'should support the console.log format for the message' : function(layout) {
       assert.equal(layout({
         data: ["thing %d", 1, "cheese"],


### PR DESCRIPTION
Added support for passing a function/closure to the logger as a message instead of a raw string.  This allows log messages to be lazily evaluated only when actually emitted (which can yield substantial performance benefits).  This was already possible using logging level-based conditional logging, but the syntax was much messier:

    if (logger.level.level < 5000) logger.trace(JSON.stringify(myBigObject));
  vs
    logger.trace(() => JSON.stringify(myBigObject));