### PR TITLE
feat(LogstashUDP): Added a way for fields to be added without dot.

### DIFF
--- a/lib/appenders/logstashUDP.js
+++ b/lib/appenders/logstashUDP.js
@@ -46,6 +46,11 @@ function logstashUDP(config, layout) {
       message: layout(loggingEvent),
       fields: config.fields
     };
+
+    const keys = Object.keys(config.fields);
+    for (let i = 0, length = keys.length; i < length; i += 1) {
+      logObject[keys[i]] = config.fields[keys[i]];
+    }
     sendLog(udp, config.host, config.port, logObject);
   };
 }

--- a/test/tap/logstashUDP-test.js
+++ b/test/tap/logstashUDP-test.js
@@ -69,6 +69,12 @@ test('logstashUDP appender', (batch) => {
       level: 'TRACE',
       category: 'myCategory'
     };
+
+    const keys = Object.keys(fields);
+    for (let i = 0, length = keys.length; i < length; i += 1) {
+        t.equal(json[keys[i]], fields[keys[i]]);
+    }
+
     t.equal(JSON.stringify(json.fields), JSON.stringify(fields));
     t.equal(json.message, 'Log event #1');
     // Assert timestamp, up to hours resolution.


### PR DESCRIPTION
I was trying to create a more consistent way of creating fields by removing the "field" and the dot for LogstashUDP. For some reason, Logstash 5.1 mutate does not process any fields with a "." in it's field.