### PR TITLE
updated loadConfiguration to not raise exceptions.

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -294,7 +294,21 @@ const configState = {};
 
 function loadConfigurationFile(filename) {
   if (filename) {
-    return JSON.parse(fs.readFileSync(filename, 'utf8'));
+    
+    let configStr;
+    try {
+      configStr = fs.readFileSync(filename, 'utf8');
+    } catch (ex) {
+      getLogger('log4js').error("Failed to open configuration file '%s'.", filename);
+      return undefined;
+    }
+
+    try {
+      return JSON.parse(configStr);
+    } catch (ex) {
+      getLogger('log4js').error("Failed to parse configuration file '%s'.", filename);
+      return undefined;
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
Made it so that configure called with a non-existent or non-parseable configuration file fails without causing problems.  

addresses Issue #438 