### PR TITLE
Bump streamroller to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "date-format": "^1.0.0",
     "debug": "^2.2.0",
     "semver": "^5.3.0",
-    "streamroller": "^0.3.0"
+    "streamroller": "^0.4.0"
   },
   "devDependencies": {
     "codecov": "^1.0.1",


### PR DESCRIPTION
Would it be possible to do a patch release (1.1.1)? We rely on this over at https://github.com/facebook/nuclide for logging and the unhandled exceptions are causing server crashes :(