### PR TITLE
Properly flush file appenders on shutdown

### DIFF
--- a/lib/appenders/dateFile.js
+++ b/lib/appenders/dateFile.js
@@ -82,13 +82,9 @@ function shutdown(cb) {
   }
 
   return openFiles.forEach((file) => {
-    if (!file.write(eol, 'utf-8')) {
-      file.once('drain', () => {
-        file.end(complete);
-      });
-    } else {
+    file.write('', 'utf-8', () => {
       file.end(complete);
-    }
+    });
   });
 }
 

--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -113,13 +113,9 @@ function shutdown(cb) {
   }
 
   return openFiles.forEach((file) => {
-    if (!file.write(eol, 'utf-8')) {
-      file.once('drain', () => {
-        file.end(complete);
-      });
-    } else {
+    file.write('', 'utf-8', () => {
       file.end(complete);
-    }
+    });
   });
 }
 

--- a/test/tap/dateFileAppender-test.js
+++ b/test/tap/dateFileAppender-test.js
@@ -189,5 +189,31 @@ test('../../lib/appenders/dateFile', (batch) => {
     t.end();
   });
 
+  batch.test('should flush logs on shutdown', (t) => {
+    const testFile = path.join(__dirname, 'date-appender-default.log');
+    const appender = require('../../lib/appenders/dateFile').appender(testFile);
+    const logger = log4js.getLogger('default-settings');
+
+    log4js.clearAppenders();
+    log4js.addAppender(appender, 'default-settings');
+
+    logger.info('1');
+    logger.info('2');
+    logger.info('3');
+    t.teardown(() => { removeFile('date-appender-default.log'); });
+
+    log4js.shutdown(() => {
+      fs.readFile(testFile, 'utf8', (err, fileContents) => {
+        // 3 lines of output, plus the trailing newline.
+        t.equal(fileContents.split(EOL).length, 4);
+        t.match(
+          fileContents,
+          /\[\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{3}] \[INFO] default-settings - /
+        );
+        t.end();
+      });
+    });
+  });
+
   batch.end();
 });


### PR DESCRIPTION
The current file appender `shutdown` functions don't actually work properly.
`write` is fully asynchronous whether it returns true or false, so we can't just `end` the stream immediately - this causes a "write after end" error.

I think the right thing to do here is to write an empty string and wait for the callback to trigger. Since writes are sequential and logging gets disabled prior to shutdown, this should ensure that any earlier writes have already occurred.

In addition, I don't think we actually need the draining logic - if `write` returns false, the data is still buffered and written. It's just a signal to the caller that any further writes should wait for a drain, which is irrelevant here since this is the last thing we're going to be writing.

Added a unit test - this test fails with the existing code (only one line is written).

Fixes #270 and #385