### PR TITLE
bugfix for issue #457

### DIFF
--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -249,7 +249,7 @@ function patternLayout(pattern, tokens, timezoneOffset) {
   }
 
   function pid(loggingEvent) {
-    return loggingEvent && loggingEvent.pid ? loggingEvent.pid : process.pid;
+    return loggingEvent && loggingEvent.pid ? loggingEvent.pid.toString() : process.pid.toString();
   }
 
   function clusterInfo(loggingEvent, specifier) {


### PR DESCRIPTION
bugfix for issue #457 "pattern %z (process id) can not be padded/truncated"
see https://github.com/nomiddlename/log4js-node/issues/457