### PR TITLE
docs(file): fix maxLogSize

### DIFF
--- a/docs/file.md
+++ b/docs/file.md
@@ -38,7 +38,7 @@ This example will result in a single log file (`all-the-logs.log`) containing th
 ```javascript
 log4js.configure({
   appenders: {
-    everything: { type: 'file', filename: 'all-the-logs.log', maxLogSize: 10458760, backups: 3, compress: true }
+    everything: { type: 'file', filename: 'all-the-logs.log', maxLogSize: 10485760, backups: 3, compress: true }
   },
   categories: {
     default: { appenders: [ 'everything' ], level: 'debug'}


### PR DESCRIPTION
`maxLogSize` is 10Mb in the description below.
However, 10,458,760 bytes is 9.97425079346 Mb.