### PR TITLE
fix: sticky fields

### DIFF
--- a/lib/appenders/logstashUDP.js
+++ b/lib/appenders/logstashUDP.js
@@ -37,28 +37,34 @@ function logstashUDP(config, layout) {
      @version is the version number of this json schema
      Every other field is valid and fine.
      */
+
+    const fields = {};
+    Object.keys(config.fields).forEach((key) => {
+      fields[key] = config.fields[key];
+    });
+
     /* eslint no-prototype-builtins:1,no-restricted-syntax:[1, "ForInStatement"] */
     if (loggingEvent.data.length > 1) {
       const secondEvData = loggingEvent.data[1];
       Object.keys(secondEvData).forEach((key) => {
-        config.fields[key] = secondEvData[key];
+        fields[key] = secondEvData[key];
       });
     }
-    config.fields.level = loggingEvent.level.levelStr;
-    config.fields.category = loggingEvent.categoryName;
+    fields.level = loggingEvent.level.levelStr;
+    fields.category = loggingEvent.categoryName;
 
     const logObject = {
       '@version': '1',
       '@timestamp': (new Date(loggingEvent.startTime)).toISOString(),
       type: type,
       message: layout(loggingEvent),
-      fields: config.fields
+      fields: fields
     };
 
-    const keys = Object.keys(config.fields);
-    for (let i = 0, length = keys.length; i < length; i += 1) {
-      logObject[keys[i]] = config.fields[keys[i]];
-    }
+    Object.keys(fields).forEach((key) => {
+      logObject[key] = fields[key];
+    });
+
     sendLog(udp, config.host, config.port, logObject);
   }
 


### PR DESCRIPTION
Fixed an issue that was introduced in commit 6746e2e0488f3c900fd358af0a50d4795df65de7
All fields became sticky, so each time a field was sent via a message, it showed up in all messages after that