### PR TITLE
feat(logstashUDP): Added args config option

### DIFF
--- a/docs/logstashUDP.md
+++ b/docs/logstashUDP.md
@@ -11,6 +11,7 @@ This appender sends log events to a [logstash](https://www.elastic.co/products/l
 * `category` - `string` (optional) - used for the `type` field of the logstash data if `logType` is not defined
 * `fields` - `object` (optional) - extra fields to log with each event
 * `layout` - (optional, defaults to dummyLayout) - used for the `message` field of the logstash data (see [layouts](layouts.md))
+* `args` - (optional, defaults to both) - determines how to log arguments and configuration fields: `direct` logs them as direct properties of the log object, `fields` logs them as child properties of the `fields` property, and `both` logs both.
 
 ## Example
 ```javascript

--- a/lib/appenders/logstashUDP.js
+++ b/lib/appenders/logstashUDP.js
@@ -23,6 +23,22 @@ function logstashUDP(config, layout) {
     config.fields = {};
   }
 
+  function checkArgs(argsValue, logUnderFields) {
+    if ((!argsValue) || (argsValue === 'both')) {
+      return true;
+    }
+
+    if (logUnderFields && (argsValue === 'fields')) {
+      return true;
+    }
+
+    if ((!logUnderFields) && (argsValue === 'direct')) {
+      return true;
+    }
+
+    return false;
+  }
+
   function log(loggingEvent) {
     /*
      https://gist.github.com/jordansissel/2996677
@@ -57,13 +73,18 @@ function logstashUDP(config, layout) {
       '@version': '1',
       '@timestamp': (new Date(loggingEvent.startTime)).toISOString(),
       type: type,
-      message: layout(loggingEvent),
-      fields: fields
+      message: layout(loggingEvent)
     };
 
-    Object.keys(fields).forEach((key) => {
-      logObject[key] = fields[key];
-    });
+    if (checkArgs(config.args, true)) {
+      logObject.fields = fields;
+    }
+
+    if (checkArgs(config.args, false)) {
+      Object.keys(fields).forEach((key) => {
+        logObject[key] = fields[key];
+      });
+    }
 
     sendLog(udp, config.host, config.port, logObject);
   }

--- a/test/tap/logstashUDP-test.js
+++ b/test/tap/logstashUDP-test.js
@@ -143,6 +143,49 @@ test('logstashUDP appender', (batch) => {
     t.end();
   });
 
+  batch.test('use direct args', (t) => {
+    const setup = setupLogging('myLogger', {
+      host: '127.0.0.1',
+      port: 10001,
+      type: 'logstashUDP',
+      category: 'myLogger',
+      args: 'direct',
+      layout: {
+        type: 'dummy'
+      }
+    });
+
+    setup.logger.log('info', 'Log event with fields', { extra1: 'value1', extra2: 'value2' });
+    const json = JSON.parse(setup.results.buffer.toString());
+
+    t.equal(json.extra1, 'value1');
+    t.equal(json.extra2, 'value2');
+    t.equal(json.fields, undefined);
+    t.end();
+  });
+
+  batch.test('use fields args', (t) => {
+    const setup = setupLogging('myLogger', {
+      host: '127.0.0.1',
+      port: 10001,
+      type: 'logstashUDP',
+      category: 'myLogger',
+      args: 'fields',
+      layout: {
+        type: 'dummy'
+      }
+    });
+
+    setup.logger.log('info', 'Log event with fields', { extra1: 'value1', extra2: 'value2' });
+    const json = JSON.parse(setup.results.buffer.toString());
+
+    t.equal(json.extra1, undefined);
+    t.equal(json.extra2, undefined);
+    t.equal(json.fields.extra1, 'value1');
+    t.equal(json.fields.extra2, 'value2');
+    t.end();
+  });
+
   batch.test('shutdown should close sockets', (t) => {
     const setup = setupLogging('myLogger', {
       host: '127.0.0.1',


### PR DESCRIPTION
Added a config option called args, to determine how to log args:
both (default for backward compatibility): under the fields property and as direct properties of the log object.
fields: only under the fields property.
direct: only as direct propertiesd of the log object.