### PR TITLE
In the above example 'tasks' does not exist

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -19,7 +19,7 @@ Then your v2 config should be something like this:
 {
   appenders: {
     out: { type: 'console' },
-    tasks: {
+    task: {
       type: 'dateFile',
       filename: 'logs/task',
       pattern: '-dd.log',


### PR DESCRIPTION
but 'task' does. This tripped us up while migrating an older project using this library.