### PR TITLE
Fixed types definition of #configure and #levels

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,9 +9,22 @@ export declare function getLogger(category?: string): Logger;
 
 export declare function configure(configuration: Configuration): void;
 
+export declare function levels(): Levels;
+
 export declare interface Configuration {
+  levels?: Levels;
   appenders: { [index: string]: any };
   categories: { [index: string]: { appenders: string[], level: string } };
+  pm2?: boolean;
+  pm2InstanceVar?: string;
+  disableClustering?: boolean;
+}
+
+export declare interface Levels {
+  [index: string]: {
+    value: number;
+    colour: string;
+  }
 }
 
 export declare interface Logger {


### PR DESCRIPTION
Version 2.3.5 breaks every application written in typescript that uses any of the optional options of the configure method. Namely:
* levels
* pm2
* pm2InstanceVar
* disableClustering

Please check if you API is covered completely before accepting pull requests that propose types definittion.

I added everything I need for now but other functions are still missing:
* Logger#is<level>Enabled()
* log4js.shutdown(cb)
* log4js.addLayout(type, fn)
* log4js.connectLogger
* others I might have missed as well